### PR TITLE
Bug 1283612 - Add Bugzilla::Extension module loader last

### DIFF
--- a/Bugzilla/Extension.pm
+++ b/Bugzilla/Extension.pm
@@ -143,7 +143,7 @@ sub modify_inc {
     # directory. We don't want Bugzilla's base lib/CGI.pm being loaded as 
     # Bugzilla::Extension::Foo::CGI or any other confusing thing like that.
     return if $package_dir eq bz_locations->{'extensionsdir'};
-    unshift(@INC, sub { __do_call($class, 'my_inc', @_) });
+    push(@INC, sub { __do_call($class, 'my_inc', @_) });
 }
 
 # This is what gets put into @INC by modify_inc.


### PR DESCRIPTION
Currently, anything that is loaded after the bugzilla extensions
are loaded has to search through each callback inserted into @INC
by Bugzilla::Extension. If you have a lot of extensions this is slow.

It is harmless to search for Bugzilla::Extension::* modules last, so
we replace the unshift with a push.