### PR TITLE
Bug 1300437 - DateTime::TimeZone::offset_as_string called incorrectly

### DIFF
--- a/Bugzilla/Migrate.pm
+++ b/Bugzilla/Migrate.pm
@@ -417,7 +417,7 @@ sub parse_date {
     }
     my $tz;
     if ($time[6]) {
-        $tz = Bugzilla->local_timezone->offset_as_string($time[6]);
+        $tz = DateTime::TimeZone->local_timezone->offset_as_string($time[6]);
     }
     else {
         $tz = $self->config('timezone');

--- a/Bugzilla/Util.pm
+++ b/Bugzilla/Util.pm
@@ -607,7 +607,7 @@ sub datetime_from {
         second => defined($time[0]) ? int($time[0]) : undef,
         # If a timezone was specified, use it. Otherwise, use the
         # local timezone.
-        time_zone => Bugzilla->local_timezone->offset_as_string($time[6]) 
+        time_zone => DateTime::TimeZone->offset_as_string($time[6])
                      || Bugzilla->local_timezone,
     );
 


### PR DESCRIPTION
Discussion on [Bug 1300437](https://bugzilla.mozilla.org/show_bug.cgi?id=1300437)