### PR TITLE
Bug 1303896 - Fix "Can't locate object method 'host' via package 'URI::_generic'"

### DIFF
--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -451,7 +451,7 @@ sub send_cookie {
     # Add the default path and the domain in.
     my $uri = URI->new(Bugzilla->params->{urlbase});
     $paramhash{'-path'} = $uri->path;
-    $paramhash{'-domain'} = $uri->host if $uri->host;
+    $paramhash{'-domain'} = $uri->host if $uri->can('host') && $uri->host;
 
     push(@{$self->{'Bugzilla_cookie_list'}}, $self->cookie(%paramhash));
 }


### PR DESCRIPTION
[Bug 1303896](https://bugzilla.mozilla.org/show_bug.cgi?id=1303896)