### PR TITLE
Bug 1309737 - Add User-Agent to the Access-Control-Allow-Headers header

### DIFF
--- a/Bugzilla/API/1_0/Server.pm
+++ b/Bugzilla/API/1_0/Server.pm
@@ -152,7 +152,7 @@ sub print_response {
     my ($self, $response) = @_;
 
     # Access Control
-    my @allowed_headers = qw(accept content-type origin x-requested-with);
+    my @allowed_headers = qw(accept content-type origin user-agent x-requested-with);
     foreach my $header (keys %{ API_AUTH_HEADERS() }) {
         # We want to lowercase and replace _ with -
         my $translated_header = $header;


### PR DESCRIPTION
Fix [Bug 1309737](https://bugzilla.mozilla.org/show_bug.cgi?id=1309737) - Add User-Agent to the Access-Control-Allow-Headers header