### PR TITLE
Bug 1287265 - Need a grippy for Preview at Description/Additional Comments 

### DIFF
--- a/skins/standard/bug.css
+++ b/skins/standard/bug.css
@@ -674,4 +674,8 @@ div#update_container {
    font-weight: bold;
 }
 
+.bz-comment {
+   resize: both;
+}
+
 /* attachment.cgi (end) */


### PR DESCRIPTION
This commit fixes bug #1287265. 
https://bugzilla.mozilla.org/show_bug.cgi?id=1287265