### PR TITLE
<option> used when no flag is set is displayed as 'X' in Safari

### DIFF
--- a/template/en/default/flag/list.html.tmpl
+++ b/template/en/default/flag/list.html.tmpl
@@ -125,7 +125,7 @@
           <option value="[% dontchange FILTER html %]">[% dontchange FILTER html %]</option>
         [% END %]
         [% IF !flag || (can_edit_flag && user.can_request_flag(type)) || flag.setter_id == user.id %]
-          <option value="X" label="X"></option>
+          <option value="X" label=" "></option>
         [% END %]
         [% IF type.is_active && can_edit_flag %]
           [% IF (type.is_requestable && user.can_request_flag(type)) || (flag && flag.status == "?") %]


### PR DESCRIPTION
After https://github.com/bugzilla/bugzilla/commit/7d0c10e71498f2909f466fc0ccda1890595bd3ff,
the <option> used when no flag is set is displayed as 'X' in Safari. This is because WebKit
displays the label when provided as per the latest HTML specification:
- https://html.spec.whatwg.org/multipage/rendering.html#the-select-element-2
- https://html.spec.whatwg.org/multipage/forms.html#concept-option-label

Chrome/Blink also display the label in standards mode, but not in quirks mode. The proposed
fix is to use a whitespace as label instead of 'X'. This renders as empty in Firefox / Chrome
and Safari and is still recognized as valid HTML as per https://validator.w3.org.