### PR TITLE
make flagtypes id a medium int

### DIFF
--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -626,7 +626,7 @@ use constant ABSTRACT_SCHEMA => {
     FIELDS => [
       id      => {TYPE => 'MEDIUMSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
       type_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         REFERENCES => {TABLE => 'flagtypes', COLUMN => 'id', DELETE => 'CASCADE'}
       },
@@ -662,7 +662,7 @@ use constant ABSTRACT_SCHEMA => {
   # "flagtypes" defines the types of flags that can be set.
   flagtypes => {
     FIELDS => [
-      id               => {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
+      id               => {TYPE => 'MEDIUMSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
       name             => {TYPE => 'varchar(50)', NOTNULL => 1},
       description      => {TYPE => 'MEDIUMTEXT',  NOTNULL => 1},
       cc_list          => {TYPE => 'varchar(200)'},
@@ -689,7 +689,7 @@ use constant ABSTRACT_SCHEMA => {
   flaginclusions => {
     FIELDS => [
       type_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         REFERENCES => {TABLE => 'flagtypes', COLUMN => 'id', DELETE => 'CASCADE'}
       },
@@ -711,7 +711,7 @@ use constant ABSTRACT_SCHEMA => {
   flagexclusions => {
     FIELDS => [
       type_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         REFERENCES => {TABLE => 'flagtypes', COLUMN => 'id', DELETE => 'CASCADE'}
       },

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -477,7 +477,7 @@ sub update_table_definitions {
 
   # 2006-08-06 LpSolit@gmail.com - Bug 347521
   $dbh->bz_alter_column('flagtypes', 'id',
-    {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1});
+    {TYPE => 'MEDIUMSERIAL', NOTNULL => 1, PRIMARYKEY => 1});
 
   $dbh->bz_alter_column('keyworddefs', 'id',
     {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1});


### PR DESCRIPTION
When running this on an old schema, checksetup will print:

```
Dropping flaginclusions
Dropping foreign key: flaginclusions.type_id -> flagtypes.id...
Updating column type_id in table flaginclusions ...
Old: smallint NOT NULL
New: mediumint NOT NULL
Dropping flagexclusions
Dropping foreign key: flagexclusions.type_id -> flagtypes.id...
Updating column type_id in table flagexclusions ...
Old: smallint NOT NULL
New: mediumint NOT NULL
Dropping flags
Dropping foreign key: flags.type_id -> flagtypes.id...
Updating column type_id in table flags ...
Old: smallint NOT NULL
New: mediumint NOT NULL
Updating column id in table flagtypes ...
Old: smallint auto_increment PRIMARY KEY NOT NULL
New: mediumint auto_increment PRIMARY KEY NOT NULL
Adding foreign key: flagexclusions.type_id -> flagtypes.id...
Adding foreign key: flaginclusions.type_id -> flagtypes.id...
Adding foreign key: flags.type_id -> flagtypes.id...
```