### PR TITLE
Add viewport meta

### DIFF
--- a/template/en/default/global/header.html.tmpl
+++ b/template/en/default/global/header.html.tmpl
@@ -89,6 +89,8 @@
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     [% END %]
 
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     [% SET yui = yui_resolve_deps(yui, yui_deps) %]
 
     [% SET css_sets = css_files(style_urls, yui, yui_css) %]


### PR DESCRIPTION
Add viewport meta to improve rendering on mobile devices. Without this meta Google Search tools would report Bugzilla pages as not suitable for mobile devices.