### PR TITLE
[Bug 1592129] remove subclass loading and driver delegation from Schema->new.

### DIFF
--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -1759,10 +1759,7 @@ sub new {
 
  Description: Public constructor method used to instantiate objects of this
               class.
- Parameters:  $driver (optional) - Used to specify the type of database.
-              This routine C<die>s if no subclass is found for the specified
-              driver.
-              $schema (optional) - A reference to a hash. Callers external
+ Parameters:  $schema (optional) - A reference to a hash. Callers external
                   to this package should never use this parameter.
  Returns:     new instance of the Schema class or a database-specific subclass
 

--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -1758,9 +1758,7 @@ sub new {
 =item C<new>
 
  Description: Public constructor method used to instantiate objects of this
-              class. However, it also can be used as a factory method to
-              instantiate database-specific subclasses when an optional
-              driver argument is supplied.
+              class.
  Parameters:  $driver (optional) - Used to specify the type of database.
               This routine C<die>s if no subclass is found for the specified
               driver.
@@ -1772,15 +1770,7 @@ sub new {
 
   my $this   = shift;
   my $class  = ref($this) || $this;
-  my $driver = shift;
 
-  if ($driver) {
-    (my $subclass = $driver) =~ s/^(\S)/\U$1/;
-    $class .= '::' . $subclass;
-    eval "require $class;";
-    die "The $class class could not be found ($subclass " . "not supported?): $@"
-      if ($@);
-  }
   die "$class is an abstract base class. Instantiate a subclass instead."
     if ($class eq __PACKAGE__);
 
@@ -2983,7 +2973,7 @@ sub deserialize_abstract {
     }
   }
 
-  return $class->new(undef, $thawed_hash);
+  return $class->new($thawed_hash);
 }
 
 #####################################################################

--- a/t/013dbschema.t
+++ b/t/013dbschema.t
@@ -19,6 +19,7 @@ use warnings;
 use lib qw(. t lib);
 use Bugzilla;
 use Bugzilla::DB::Schema;
+use Bugzilla::DB::Schema::Mysql;
 
 
 # SQL reserved words
@@ -57,7 +58,7 @@ our $schema;
 our @tables;
 
 BEGIN {
-  $schema = Bugzilla::DB::Schema->new("Mysql");
+  $schema = Bugzilla::DB::Schema::Mysql->new;
   @tables = $schema->get_table_list();
 }
 


### PR DESCRIPTION
Bugzilla::DB::Schema->new() was both a normal constructor and also a class-loading factory method. It is simpler to just do the class loading at the call-site (in Bugzilla::DB::_bz_schema).

It's not very likely extensions relied on this behavior so this should be a good
change.

This is part 1 of a series of incremental patches to allow the Schema layer to access the database connection.
