### PR TITLE
Pass a reference to db into Schema object

### DIFF
--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -1180,7 +1180,7 @@ sub _bz_schema {
   return $self->{private_bz_schema} if exists $self->{private_bz_schema};
   my $schema_class = $self->_bz_schema_class;
   eval "require $schema_class";
-  $self->{private_bz_schema} = $schema_class->new();
+  $self->{private_bz_schema} = $schema_class->new(db => $self);
   return $self->{private_bz_schema};
 }
 

--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -1773,6 +1773,8 @@ has 'schema' => (init_arg =>undef, is => 'rw');
 
 has 'db_specific' => (init_arg => undef, is => 'rw');
 
+has 'db' => (is => 'ro', weak_ref => 1, required => 1);
+
 
 #--------------------------------------------------------------------------
 sub _initialize {
@@ -2933,7 +2935,7 @@ sub serialize_abstract {
 =cut
 
 sub deserialize_abstract {
-  my ($class, $serialized, $version) = @_;
+  my ($self, $serialized, $version) = @_;
 
   my $thawed_hash;
   if ($version < 2) {
@@ -2947,7 +2949,7 @@ sub deserialize_abstract {
 
   # Version 2 didn't have the "created" key for REFERENCES items.
   if ($version < 3) {
-    my $standard = $class->new()->{abstract_schema};
+    my $standard = $self->new(db => $self->db)->{abstract_schema};
     foreach my $table_name (keys %$thawed_hash) {
       my %standard_fields = @{$standard->{$table_name}->{FIELDS} || []};
       my $table           = $thawed_hash->{$table_name};
@@ -2960,7 +2962,7 @@ sub deserialize_abstract {
     }
   }
 
-  return $class->new(_abstract_schema => $thawed_hash);
+  return $self->new(db => $self->db, _abstract_schema => $thawed_hash);
 }
 
 #####################################################################
@@ -2988,8 +2990,8 @@ object.
 =cut
 
 sub get_empty_schema {
-  my ($class) = @_;
-  return $class->deserialize_abstract(Dumper({}), SCHEMA_VERSION);
+  my ($self) = @_;
+  return $self->deserialize_abstract(Dumper({}), SCHEMA_VERSION);
 }
 
 1;

--- a/t/013dbschema.t
+++ b/t/013dbschema.t
@@ -58,7 +58,8 @@ our $schema;
 our @tables;
 
 BEGIN {
-  $schema = Bugzilla::DB::Schema::Mysql->new;
+  our $fake_db = bless {}, 'Bugzilla::DB';
+  $schema = Bugzilla::DB::Schema::Mysql->new(db => $fake_db);
   @tables = $schema->get_table_list();
 }
 


### PR DESCRIPTION
This change adds a 'db' attribute to the `Bugzilla::DB::Schema` class.
In two places (`get_empty_schema` and `deserialize_abstract`) the invocant
argument was called `$class` but was never actually a class. Those were renamed
to `$self`. It was fortunate that they were always objects because otherwise it
would have been more difficult to ensure a `db` is always present.