### PR TITLE
Add a shortcut for quoting identifiers in strings.

### DIFF
--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -24,6 +24,7 @@ use Bugzilla::Install::Localconfig;
 use Bugzilla::Util;
 use Bugzilla::Error;
 use Bugzilla::DB::Schema;
+use Bugzilla::DB::QuoteIdentifier;
 use Bugzilla::Version;
 
 use List::Util qw(max);
@@ -31,6 +32,15 @@ use Storable qw(dclone);
 
 has [qw(dsn user pass attrs)] => (is => 'ro', required => 1,);
 
+has 'qi' => (is => 'lazy');
+
+sub _build_qi {
+  my ($self) = @_;
+  my %q;
+  tie %q, 'Bugzilla::DB::QuoteIdentifier', db => $self;
+
+  return \%q;
+}
 
 # Install proxy methods to the DBI object.
 # We can't use handles() as DBIx::Connector->dbh has to be called each

--- a/Bugzilla/DB/QuoteIdentifier.pm
+++ b/Bugzilla/DB/QuoteIdentifier.pm
@@ -1,0 +1,71 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::DB::QuoteIdentifier;
+
+use 5.10.1;
+use Moo;
+
+has 'db' => (
+  is       => 'ro',
+  weak_ref => 1,
+  required => 1,
+);
+
+sub TIEHASH {
+  my ($class, @args) = @_;
+
+  return $class->new(@args);
+}
+
+sub FETCH {
+  my ($self, $key) = @_;
+
+  return $self->db->quote_identifier($key);
+}
+
+sub FIRSTKEY {
+  return;
+}
+
+sub FIRSTVALUE {
+  return;
+}
+
+sub EXISTS {
+  return 1
+}
+
+sub DELETE {
+  return 1
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Bugzilla::DB::QuoteIdentifier
+
+=head1 SYNOPSIS
+
+  my %q;
+  tie %q, 'Bugzilla::DB::QuoteIdentifier', db => Bugzilla->dbh;
+
+  is("this is $q{something}", 'this is ' . Bugzilla->dbh->quote_identifier('something'));
+
+=head1 DESCRIPTION
+
+Bugzilla has many strings with bare sql column names or table names. Sometimes,
+as in the case of MySQL 8, formerly unreserved keywords can become reserved.
+
+This module provides a shortcut for quoting identifiers in strings by way of overloading a hash
+so that we can easily call C<quote_identifier> inside double-quoted strings.
+
+=cut
+


### PR DESCRIPTION
The Bugzilla::DB object has a qi attribute which returns a special hashref
that can be used inside double-quoted strings to quote database identifiers.

```perl
  my $q = Bugzilla->dbh->qi;
  Bugzilla->dbh->do("SELECT COUNT(*) FROM $q->{groups}");
```