### PR TITLE
WIP: quote identifiers used in the Bugzilla::DB::Schema::* classes

### DIFF
--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -1994,10 +1994,10 @@ is undefined.
   my $to_table  = $references->{TABLE}  || confess "No table in reference";
   my $to_column = $references->{COLUMN} || confess "No column in reference";
   my $fk_name = $self->_get_fk_name($table, $column, $references);
-
+  my $q = $self->db->qi;
   return
-      "\n     CONSTRAINT $fk_name FOREIGN KEY ($column)\n"
-    . "     REFERENCES $to_table($to_column)\n"
+      "\n     CONSTRAINT $fk_name FOREIGN KEY ($q->{$column})\n"
+    . "     REFERENCES $q->{$to_table}($q->{$to_column})\n"
     . "      ON UPDATE $update ON DELETE $delete";
 }
 
@@ -2031,14 +2031,15 @@ sub get_add_fks_sql {
 
   my @add = $self->_column_fks_to_ddl($table, $column_fks);
 
+  my $q = $self->db->qi;
   my @sql;
   if ($self->MULTIPLE_FKS_IN_ALTER) {
-    my $alter = "ALTER TABLE $table ADD " . join(', ADD ', @add);
+    my $alter = "ALTER TABLE $q->{$table} ADD " . join(', ADD ', @add);
     push(@sql, $alter);
   }
   else {
     foreach my $fk_string (@add) {
-      push(@sql, "ALTER TABLE $table ADD $fk_string");
+      push(@sql, "ALTER TABLE $q->{$table} ADD $fk_string");
     }
   }
   return @sql;
@@ -2059,7 +2060,8 @@ sub get_drop_fk_sql {
   my ($self, $table, $column, $references) = @_;
   my $fk_name = $self->_get_fk_name($table, $column, $references);
 
-  return ("ALTER TABLE $table DROP CONSTRAINT $fk_name");
+  my $q = $self->db->qi;
+  return ("ALTER TABLE $q->{$table} DROP CONSTRAINT $fk_name");
 }
 
 sub convert_type {
@@ -2153,7 +2155,8 @@ sub get_table_indexes_abstract {
 
 sub get_create_database_sql {
   my ($self, $name) = @_;
-  return ("CREATE DATABASE $name");
+  my $q = $self->db->qi;
+  return ("CREATE DATABASE $q->{$name}");
 }
 
 sub get_table_ddl {
@@ -2212,10 +2215,11 @@ sub _get_create_table_ddl {
 
   my (@col_lines, @fk_lines);
   my @fields = @{$thash->{FIELDS}};
+  my $q = $self->db->qi;
   while (@fields) {
     my $field = shift(@fields);
     my $finfo = shift(@fields);
-    push(@col_lines, "\t$field\t" . $self->get_type_ddl($finfo));
+    push(@col_lines, "\t$q->{$field}\t" . $self->get_type_ddl($finfo));
     if ($self->FK_ON_CREATE and $finfo->{REFERENCES}) {
       my $fk     = $finfo->{REFERENCES};
       my $fk_ddl = $self->get_fk_ddl($table, $field, $fk);
@@ -2224,7 +2228,7 @@ sub _get_create_table_ddl {
   }
 
   my $sql
-    = "CREATE TABLE $table (\n" . join(",\n", @col_lines, @fk_lines) . "\n)";
+    = "CREATE TABLE $q->{$table} (\n" . join(",\n", @col_lines, @fk_lines) . "\n)";
   return $sql;
 
 }
@@ -2245,10 +2249,11 @@ sub _get_create_index_ddl {
 
   my ($self, $table_name, $index_name, $index_fields, $index_type) = @_;
 
+  my $q = $self->db->qi;
   my $sql = "CREATE ";
   $sql .= "$index_type " if ($index_type && $index_type eq 'UNIQUE');
   $sql
-    .= "INDEX $index_name ON $table_name \(" . join(", ", @$index_fields) . "\)";
+    .= "INDEX $q->{$index_name} ON $q->{$table_name} \(" . join(", ", map { $q->{$_} } @$index_fields) . "\)";
 
   return ($sql);
 
@@ -2274,15 +2279,16 @@ sub get_add_column_ddl {
 
   my ($self, $table, $column, $definition, $init_value) = @_;
   my @statements;
+  my $q = $self->db->qi;
   push(@statements,
-        "ALTER TABLE $table "
+        "ALTER TABLE $q->{$table} "
       . $self->ADD_COLUMN
-      . " $column "
+      . " $q->{$column} "
       . $self->get_type_ddl($definition));
 
   # XXX - Note that although this works for MySQL, most databases will fail
   # before this point, if we haven't set a default.
-  (push(@statements, "UPDATE $table SET $column = $init_value"))
+  (push(@statements, "UPDATE $q->{$table} SET $q->{$column} = $init_value"))
     if defined $init_value;
 
   if (defined $definition->{REFERENCES}) {
@@ -2350,6 +2356,7 @@ sub get_alter_column_ddl {
 
   my $self = shift;
   my ($table, $column, $new_def, $set_nulls_to) = @_;
+  my $q = $self->db->qi;
 
   my @statements;
   my $old_def  = $self->get_column_abstract($table, $column);
@@ -2376,7 +2383,7 @@ sub get_alter_column_ddl {
 
   # If we went from having a default to not having one
   elsif (!defined $default && defined $default_old) {
-    push(@statements, "ALTER TABLE $table ALTER COLUMN $column" . " DROP DEFAULT");
+    push(@statements, "ALTER TABLE $q->{$table} ALTER COLUMN $q->{$column}" . " DROP DEFAULT");
   }
 
   # If we went from no default to a default, or we changed the default.
@@ -2384,28 +2391,28 @@ sub get_alter_column_ddl {
     || ($default ne $default_old))
   {
     push(@statements,
-      "ALTER TABLE $table ALTER COLUMN $column " . " SET DEFAULT $default");
+      "ALTER TABLE $q->{$table} ALTER COLUMN $q->{$column} " . " SET DEFAULT $default");
   }
 
   # If we went from NULL to NOT NULL.
   if (!$old_def->{NOTNULL} && $new_def->{NOTNULL}) {
     push(@statements, $self->_set_nulls_sql(@_));
-    push(@statements, "ALTER TABLE $table ALTER COLUMN $column" . " SET NOT NULL");
+    push(@statements, "ALTER TABLE $q->{$table} ALTER COLUMN $q->{$column}" . " SET NOT NULL");
   }
 
   # If we went from NOT NULL to NULL
   elsif ($old_def->{NOTNULL} && !$new_def->{NOTNULL}) {
-    push(@statements, "ALTER TABLE $table ALTER COLUMN $column" . " DROP NOT NULL");
+    push(@statements, "ALTER TABLE $q->{$table} ALTER COLUMN $q->{$column}" . " DROP NOT NULL");
   }
 
   # If we went from not being a PRIMARY KEY to being a PRIMARY KEY.
   if (!$old_def->{PRIMARYKEY} && $new_def->{PRIMARYKEY}) {
-    push(@statements, "ALTER TABLE $table ADD PRIMARY KEY ($column)");
+    push(@statements, "ALTER TABLE $q->{$table} ADD PRIMARY KEY ($q->{$column})");
   }
 
   # If we went from being a PK to not being a PK
   elsif ($old_def->{PRIMARYKEY} && !$new_def->{PRIMARYKEY}) {
-    push(@statements, "ALTER TABLE $table DROP PRIMARY KEY");
+    push(@statements, "ALTER TABLE $q->{$table} DROP PRIMARY KEY");
   }
 
   return @statements;
@@ -2416,6 +2423,7 @@ sub get_alter_column_ddl {
 sub _set_nulls_sql {
   my ($self, $table, $column, $new_def, $set_nulls_to) = @_;
   my $default = $new_def->{DEFAULT};
+  my $q = $self->db->qi;
 
   # If we have a set_nulls_to, that overrides the DEFAULT
   # (although nobody would usually specify both a default and
@@ -2427,7 +2435,7 @@ sub _set_nulls_sql {
   }
   my @sql;
   if (defined $default) {
-    push(@sql, "UPDATE $table SET $column = $default" . "  WHERE $column IS NULL");
+    push(@sql, "UPDATE $q->{$table} SET $q->{$column} = $default" . "  WHERE $column IS NULL");
   }
   return @sql;
 }
@@ -2462,7 +2470,9 @@ sub get_drop_column_ddl {
 =cut
 
   my ($self, $table, $column) = @_;
-  return ("ALTER TABLE $table DROP COLUMN $column");
+
+  my $q = $self->db->qi;
+  return ("ALTER TABLE $q->{$table} DROP COLUMN $q->{$column}");
 }
 
 =item C<get_drop_table_ddl($table)>
@@ -2475,7 +2485,9 @@ sub get_drop_column_ddl {
 
 sub get_drop_table_ddl {
   my ($self, $table) = @_;
-  return ("DROP TABLE $table");
+
+  my $q = $self->db->qi;
+  return ("DROP TABLE $q->{$table}");
 }
 
 sub get_rename_column_ddl {
@@ -2525,7 +2537,8 @@ Gets SQL to rename a table in the database.
 =cut
 
   my ($self, $old_name, $new_name) = @_;
-  return ("ALTER TABLE $old_name RENAME TO $new_name");
+  my $q = $self->db->qi;
+  return ("ALTER TABLE $q->{$old_name} RENAME TO $q->{$new_name}");
 }
 
 =item C<delete_table($name)>

--- a/Bugzilla/DB/Schema/Mysql.pm
+++ b/Bugzilla/DB/Schema/Mysql.pm
@@ -146,11 +146,12 @@ sub _get_create_index_ddl {
 
   my ($self, $table_name, $index_name, $index_fields, $index_type) = @_;
 
+  my $q = $self->db->qi;
   my $sql = "CREATE ";
   $sql .= "$index_type "
     if ($index_type eq 'UNIQUE' || $index_type eq 'FULLTEXT');
-  $sql .= "INDEX \`$index_name\` ON $table_name \("
-    . join(", ", @$index_fields) . "\)";
+  $sql .= "INDEX $q->{$index_name} ON $q->{$table_name} \("
+    . join(", ", map { $q->{$_} } @$index_fields) . "\)";
 
   return ($sql);
 
@@ -181,11 +182,12 @@ sub get_alter_column_ddl {
     delete $new_def_copy{PRIMARYKEY};
   }
 
+  my $q = $self->db->qi;
   my @statements;
 
   push(
-    @statements, "UPDATE $table SET $column = $set_nulls_to
-                        WHERE $column IS NULL"
+    @statements, "UPDATE $q->{$table} SET $q->{$column} = $set_nulls_to
+                        WHERE $q->{$column} IS NULL"
   ) if defined $set_nulls_to;
 
   # Calling SET DEFAULT or DROP DEFAULT is *way* faster than calling
@@ -198,11 +200,11 @@ sub get_alter_column_ddl {
     && $self->columns_equal(\%new_defaultless, \%old_defaultless))
   {
     if (!defined $new_def->{DEFAULT}) {
-      push(@statements, "ALTER TABLE $table ALTER COLUMN $column DROP DEFAULT");
+      push(@statements, "ALTER TABLE $q->{$table} ALTER COLUMN $q->{$column} DROP DEFAULT");
     }
     else {
       push(
-        @statements, "ALTER TABLE $table ALTER COLUMN $column
+        @statements, "ALTER TABLE $q->{$table} ALTER COLUMN $q->{$column}
                                SET DEFAULT " . $new_def->{DEFAULT}
       );
     }
@@ -210,15 +212,15 @@ sub get_alter_column_ddl {
   else {
     my $new_ddl = $self->get_type_ddl(\%new_def_copy);
     push(
-      @statements, "ALTER TABLE $table CHANGE COLUMN 
-                       $column $column $new_ddl"
+      @statements, "ALTER TABLE $q->{$table} CHANGE COLUMN 
+                       $q->{$column} $q->{$column} $new_ddl"
     );
   }
 
   if ($old_def->{PRIMARYKEY} && !$new_def->{PRIMARYKEY}) {
 
     # Dropping a PRIMARY KEY needs an explicit DROP PRIMARY KEY
-    push(@statements, "ALTER TABLE $table DROP PRIMARY KEY");
+    push(@statements, "ALTER TABLE $q->{$table} DROP PRIMARY KEY");
   }
 
   return @statements;
@@ -227,7 +229,8 @@ sub get_alter_column_ddl {
 sub get_drop_fk_sql {
   my ($self, $table, $column, $references) = @_;
   my $fk_name = $self->_get_fk_name($table, $column, $references);
-  my @sql     = ("ALTER TABLE $table DROP FOREIGN KEY $fk_name");
+  my $q       = $self->db->qi;
+  my @sql     = ("ALTER TABLE $a->{$table} DROP FOREIGN KEY $fk_name");
   my $dbh     = Bugzilla->dbh;
 
   # MySQL requires, and will create, an index on any column with
@@ -242,7 +245,8 @@ sub get_drop_fk_sql {
 
 sub get_drop_index_ddl {
   my ($self, $table, $name) = @_;
-  return ("DROP INDEX \`$name\` ON $table");
+  my $q = $self->db->qi;
+  return ("DROP INDEX $q->{$name} ON $q->{$table}");
 }
 
 # A special function for MySQL, for renaming a lot of indexes.
@@ -255,18 +259,16 @@ sub get_rename_indexes_ddl {
   my ($self, $table, %indexes) = @_;
   my @keys = keys %indexes or return ();
 
-  my $sql = "ALTER TABLE $table ";
+  my $q = $self->db->qi;
+  my $sql = "ALTER TABLE $q->{$table} ";
 
   foreach my $old_name (@keys) {
     my $name = $indexes{$old_name}->{NAME};
     my $type = $indexes{$old_name}->{TYPE};
     $type ||= 'INDEX';
-    my $fields = join(',', @{$indexes{$old_name}->{FIELDS}});
+    my $fields = join(',', map { $q->{$_} } @{$indexes{$old_name}->{FIELDS}});
 
-    # $old_name needs to be escaped, sometimes, because it was
-    # a reserved word.
-    $old_name = '`' . $old_name . '`';
-    $sql .= " ADD $type $name ($fields), DROP INDEX $old_name,";
+    $sql .= " ADD $type $q->{$name} ($fields), DROP INDEX $q->{$old_name},";
   }
 
   # Remove the last comma.
@@ -276,7 +278,9 @@ sub get_rename_indexes_ddl {
 
 sub get_set_serial_sql {
   my ($self, $table, $column, $value) = @_;
-  return ("ALTER TABLE $table AUTO_INCREMENT = $value");
+  
+  my $q = $self->db->qi;
+  return ("ALTER TABLE $q->{$table} AUTO_INCREMENT = $value");
 }
 
 # Converts a DBI column_info output to an abstract column definition.
@@ -414,7 +418,9 @@ sub get_rename_column_ddl {
 
   # MySQL doesn't like having the PRIMARY KEY statement in a rename.
   $def =~ s/PRIMARY KEY//i;
-  return ("ALTER TABLE $table CHANGE COLUMN $old_name $new_name $def");
+
+  my $q = $self->db->qi;
+  return ("ALTER TABLE $q->{$table} CHANGE COLUMN $q->{$old_name} $q->{$new_name} $def");
 }
 
 1;


### PR DESCRIPTION
So far this does the base class and Mysql.
It probably breaks the sqlite code, as sqlite *parses* the sql from the base
class I'll fix this next.

This depends on changes in #88 and #87 but does not include those commits, so it can reviewed separately.