### PR TITLE
add upsert support

### DIFF
--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -488,6 +488,13 @@ sub sql_fulltext_search {
     "CASE WHEN (" . join(" AND ", @words) . ") THEN 1 ELSE 0 END";
 }
 
+sub sql_upsert {
+  my ($self, $table, $hash) = @_;
+
+  ThrowCodeError('method_not_implemented',
+    {class => blessed($self), method => 'sql_upsert'});
+}
+
 #####################################################################
 # General Info Methods
 #####################################################################
@@ -1223,6 +1230,13 @@ sub bz_table_indexes {
 sub bz_table_list {
   my ($self) = @_;
   return $self->_bz_real_schema->get_table_list();
+}
+
+sub bz_do_upsert {
+  my ($self, $table, $hash) = @_;
+  my ($sql, $bind) = $self->sql_upsert($table, $hash);
+
+  $self->do($sql, undef, @$bind);
 }
 
 #####################################################################

--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -256,6 +256,16 @@ sub sql_group_by {
   return "GROUP BY $needed_columns";
 }
 
+sub sql_upsert {
+  my ($self, $table, $hash) = @_;
+  my @keys         = keys %$hash;
+  my @values       = @$hash{@keys};
+  my $columns      = join(', ', map {"`$_`"} @keys);
+  my $placeholders = join(', ', map {"?"} 1 .. @keys);
+
+  return ("REPLACE INTO `$table` ($columns) VALUES ($placeholders)", \@values);
+}
+
 sub bz_explain {
   my ($self, $sql) = @_;
   my $sth = $self->prepare("EXPLAIN $sql");

--- a/template/en/default/global/code-error.html.tmpl
+++ b/template/en/default/global/code-error.html.tmpl
@@ -262,6 +262,9 @@
     There was an error sending mail from '[% mail.header('From') FILTER html %]'
     to '[% mail.header('To') FILTER html %]':
     [%+ msg FILTER html %]
+  [% ELSIF error == "method_not_implemented" %]
+    There was an error because '[% class FILTER html %]' does not implement the method
+    '[% method FILTER html %]'
 
   [% ELSIF error == "missing_series_id" %]
     Having inserted a series into the database, no series_id was returned for


### PR DESCRIPTION
This adds support for doing upserts to Bugzilla's data model. The sql_upsert() method needs to be implemented for sqlite, oracle, and postgres before this can be merged.