### PR TITLE
fix regexp that is not compatible with mysql 8

### DIFF
--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -4115,7 +4115,7 @@ sub _add_password_salt_separator {
   my $profiles
     = $dbh->selectall_arrayref(
         "SELECT userid, cryptpassword FROM profiles WHERE ("
-      . $dbh->sql_regexp("cryptpassword", "'^[^,]+{'")
+      . $dbh->sql_regexp("cryptpassword", "'^[^,]+\\\\{'")
       . ")");
 
   if (@$profiles) {


### PR DESCRIPTION
In mysql 8, `{` must be escaped always. I hope this is valid with postgres and sqlite.