### PR TITLE
Ensure that mysql keywords are always quoted

### DIFF
--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -137,8 +137,7 @@ sub quote {
 sub quote_identifier {
   my ($self, $ident) = @_;
   unless ($ident =~ /^\w+$/) {
-    carp
-      "Quoted identifier $ident is possible a mistake: generally you don't want to quote punctuation or spaces";
+    carp "Quoting identifier $ident is possibly a mistake, it will not be quoted.";
     return $ident;
   }
 

--- a/Bugzilla/DB/QuoteIdentifier.pm
+++ b/Bugzilla/DB/QuoteIdentifier.pm
@@ -10,34 +10,441 @@ package Bugzilla::DB::QuoteIdentifier;
 use 5.10.1;
 use Moo;
 
-has 'db' => (is => 'ro', weak_ref => 1, required => 1,);
+has 'db' =>
+  (is => 'ro', required => 1, handles => [qw[quote quote_identifier]]);
 
-sub TIEHASH {
-  my ($class, @args) = @_;
+has sql_identifier_quote_char => (is => 'ro', required => 1);
 
-  return $class->new(@args);
+extends 'Parser::MGC';
+
+sub _build_sql_identifier_quote_char {
+  my ($self) = @_;
+
+  return $self->db->dbh->get_info(29);
 }
 
-sub FETCH {
-  my ($self, $key) = @_;
+sub FOREIGNBUILDARGS {
+  my ($self, %options) = @_;
 
-  return $self->db->quote_identifier($key);
+  $options{patterns}{string_delim} = qr/[']/;
+
+  return %options;
 }
 
-sub FIRSTKEY {
-  return;
+sub parse {
+  my ($self) = @_;
+  my $distinct = $self->maybe_expect(qr/DISTINCT/i);
+
+  ["select", $distinct, $self->list_of(",", sub { $self->parse_selection })];
 }
 
-sub FIRSTVALUE {
-  return;
+sub parse_selection {
+  my ($self) = @_;
+  my $expr   = $self->parse_expr;
+  my $alias  = $self->maybe(sub {
+    $self->generic_token('as', qr/AS/i);
+    $self->parse_ident;
+  });
+
+  defined($alias) ? ["alias", $alias, $expr] : $expr;
 }
 
-sub EXISTS {
-  return 1;
+sub parse_args {
+  my ($self) = @_;
+
+  $self->list_of(",", sub { $self->parse_expr });
 }
 
-sub DELETE {
-  return 1;
+sub parse_expr {
+  my ($self) = @_;
+
+  $self->parse_expr_10();
+}
+
+sub parse_expr_10 {
+  my ($self) = @_;
+
+  $self->any_of(
+    sub { $self->parse_case },
+    sub {
+      my $val     = $self->parse_expr_9;
+      my $min_max = $self->maybe(sub {
+        $self->expect(qr/BETWEEN/i);
+        $self->commit;
+        my $min = $self->parse_expr_9;
+        $self->expect(qr/AND/i);
+        $self->commit;
+        my $max = $self->parse_expr_9;
+        [$min, $max];
+      });
+      defined($min_max) ? ["between", $val, @$min_max] : $val;
+    }
+  );
+}
+
+sub parse_case {
+  my ($self) = @_;
+
+  $self->committed_scope_of(qr/CASE/i, 'parse_case_body', qr/END/i);
+}
+
+sub parse_case_body {
+  my ($self) = @_;
+
+  [
+    "case",
+    $self->parse_expr_9,
+    $self->sequence_of(sub {
+      $self->any_of(
+        sub {
+          $self->expect(qr/WHEN/i);
+          $self->commit;
+          my $compare = $self->parse_expr_9;
+          $self->expect(qr/THEN/i);
+          $self->commit;
+          my $result = $self->parse_expr_9;
+          ["when", $compare, $result];
+        },
+        sub {
+          $self->expect(qr/ELSE/i);
+          $self->commit;
+          my $result = $self->parse_expr_9;
+          ["else", $result];
+        }
+      );
+    })
+  ];
+}
+
+sub parse_expr_9 {
+  my ($self) = @_;
+
+  $self->parse_operators(
+    'parse_expr_8',
+    qw( = <=> >= > <= < <> != ),
+    qr/IS(?:\s+NOT)?/i,
+    qr/(?:NOT\s+)?LIKE/i,
+    qr/(?:NOT\s+)?REGEXP/i,
+    sub {
+      my ($ref_val) = @_;
+      my $type = $self->maybe_expect(qr/NOT/i) ? "NOT IN" : "IN";
+      $self->expect(qr/IN/i);
+      $self->commit;
+      my $in_args = $self->committed_scope_of('(', 'parse_args', ')');
+      $$ref_val = ["inop", $type, $$ref_val, $in_args];
+    },
+  );
+}
+
+sub parse_expr_8 {
+  my ($self) = @_;
+
+  $self->parse_operators('parse_expr_7', qw( | ));
+}
+
+sub parse_expr_7 {
+  my ($self) = @_;
+
+  $self->parse_operators('parse_expr_6', qw( & ));
+}
+
+sub parse_expr_6 {
+  my ($self) = @_;
+
+  $self->parse_operators('parse_expr_5', qw( << >> ));
+}
+
+sub parse_expr_5 {
+  my ($self) = @_;
+
+  $self->parse_operators('parse_expr_4', qw( + - ));
+}
+
+sub parse_expr_4 {
+  my ($self) = @_;
+
+  $self->parse_operators('parse_expr_3', qw( * / % DIV MOD ));
+}
+
+sub parse_expr_3 {
+  my ($self) = @_;
+
+  $self->parse_operators('parse_expr_1', qw( ^ ));
+}
+
+sub parse_expr_1 {
+  my ($self) = @_;
+
+  $self->any_of(
+    sub {
+      $self->expect(qr/INTERVAL/i);
+      $self->commit;
+      my $expr = $self->parse_expr_0;
+      $self->commit;
+      my $unit = $self->parse_unit;
+      ["interval", $expr, $unit];
+    },
+    sub { $self->parse_expr_0 },
+  );
+}
+
+sub parse_unit {
+  my ($self) = @_;
+  my @units = qw(
+    MICROSECOND SECOND MINUTE HOUR DAY WEEK MONTH QUARTER YEAR
+    SECOND_MICROSECOND MINUTE_MICROSECOND MINUTE_SECOND HOUR_MICROSECOND
+    HOUR_SECOND HOUR_MINUTE DAY_MICROSECOND DAY_SECOND DAY_MINUTE DAY_HOUR
+    YEAR_MONTH
+  );
+
+  $self->token_kw(@units);
+}
+
+sub parse_expr_0 {
+  my ($self) = @_;
+
+  $self->any_of(
+    sub { ["parens", $self->committed_scope_of('(', 'parse_expr', ')')]; },
+    sub { $self->expect(qr/NULL/i);         ["const", "NULL"] },
+    sub { $self->expect(qr/TRUE/i);         ["const", "TRUE"] },
+    sub { $self->expect(qr/FALSE/i);        ["const", "FALSE"] },
+    sub { $self->expect(qr/CURRENT_DATE/i); ["const", "CURRENT_DATE"] },
+    sub { $self->expect('?');               ["const", "?"] },
+    sub { $self->expect('!');               ["unop",  "!", $self->parse_expr_0] },
+    sub { $self->expect('-');               ["unop",  "-", $self->parse_expr_0] },
+    sub { $self->expect('~');               ["unop",  "~", $self->parse_expr_0] },
+    sub { $self->token_number },
+    sub { $self->parse_count },
+    sub { $self->parse_cast },
+    sub { $self->parse_call },
+    sub { ["ident", $self->parse_qualified_ident] },
+    sub { ["ident", $self->parse_ident] },
+    sub { ["quote", $self->token_string] },
+  );
+}
+
+sub parse_count {
+  my ($self) = @_;
+
+  $self->expect(qr/COUNT/i);
+  $self->committed_scope_of(
+    '(',
+    sub {
+      my ($self) = @_;
+      $self->any_of(
+        sub { $self->expect('*'); $self->commit; ['count', '*'] },
+        sub {
+          $self->expect(qr/DISTINCT/i);
+          $self->commit;
+          ['count', 'distinct', $self->parse_args];
+        },
+        sub { ["call", "COUNT", $self->parse_args] },
+      );
+    },
+    ')'
+  );
+}
+
+sub parse_cast {
+  my ($self) = @_;
+
+  $self->expect(qr/CAST/i);
+  $self->committed_scope_of(
+    '(',
+    sub {
+      my ($self) = @_;
+      my $expr = $self->parse_expr;
+      $self->expect(qr/AS/i);
+      my $type = $self->token_ident;
+      ["cast", $expr, $type];
+    },
+    ')'
+  );
+}
+
+sub parse_call {
+  my ($self) = @_;
+  my $ident = $self->token_ident;
+
+  ["call", $ident, $self->committed_scope_of('(', 'parse_args', ')')];
+}
+
+sub parse_qualified_ident {
+  my ($self) = @_;
+  my $table = $self->parse_ident;
+  $self->expect('.');
+  my $column = $self->parse_ident;
+
+  ($table, $column);
+}
+
+sub parse_ident {
+  my ($self) = @_;
+
+  $self->any_of(
+    sub { $self->token_ident },
+    sub {
+      my $char = $self->sql_identifier_quote_char;
+      my (undef, $id) = $self->expect(qr/\Q$char\E\s*([^$char]+?)\s*\Q$char\E/);
+      $id;
+    },
+  );
+}
+
+sub parse_operators {
+  my ($self, $method, @operators) = @_;
+  my $val = $self->$method;
+  my @ops;
+
+  foreach my $op (@operators) {
+    if (ref $op eq 'CODE') {
+      push @ops, sub {
+        $op->(\$val);
+        1;
+      };
+    }
+    else {
+      push @ops, sub {
+        $op = $self->expect($op);
+        $self->commit;
+        $val = ["binop", uc $op, $val, $self->$method];
+        1;
+      }
+    }
+  }
+  push @ops, sub {0};
+
+  for (;;) {
+    $self->any_of(@ops) or last;
+  }
+
+  return $val;
+}
+
+sub to_string {
+  my ($self, $node) = @_;
+  if (ref $node) {
+    my $method = '_to_string_' . shift @$node;
+    $self->$method(@$node);
+  }
+  else {
+    return $node;
+  }
+}
+
+sub _to_string_select {
+  my ($self, $distinct, $selection) = @_;
+  my $prefix = $distinct ? uc "$distinct " : "";
+
+  $prefix . join(', ', map { $self->to_string($_) } @$selection);
+}
+
+sub _to_string_ident {
+  my $self = shift;
+  if (@_ == 2) {
+    $self->quote_identifier($_[0]) . "." . $self->quote_identifier($_[1]);
+  }
+  else {
+    $self->quote_identifier($_[0]);
+  }
+}
+
+sub _to_string_const {
+  my ($self, $const) = @_;
+
+  return $const;
+}
+
+sub _to_string_count {
+  my ($self, $type, $args) = @_;
+  if ($type eq '*') {
+    return 'COUNT(*)';
+  }
+  elsif ($type eq 'distinct') {
+    sprintf "COUNT(DISTINCT %s)", $type,
+      join(", ", map { $self->to_string($_) } @$args);
+  }
+  else {
+    die "unsupported type of count syntax";
+  }
+}
+
+sub _to_string_cast {
+  my ($self, $expr, $type) = @_;
+
+  sprintf "CAST(%s AS %s)", $self->to_string($expr), $type;
+}
+
+sub _to_string_call {
+  my ($self, $name, $args) = @_;
+
+  sprintf "%s(%s)", $name, join(", ", map { $self->to_string($_) } @$args);
+}
+
+sub _to_string_quote {
+  my ($self, $str) = @_;
+
+  $self->quote($str);
+}
+
+sub _to_string_parens {
+  my ($self, $expr) = @_;
+
+  sprintf "(%s)", $self->to_string($expr);
+}
+
+sub _to_string_binop {
+  my ($self, $op, $left, $right) = @_;
+  $self->to_string($left) . " $op " . $self->to_string($right);
+}
+
+sub _to_string_unop {
+  my ($self, $op, $expr) = @_;
+  sprintf "%s %s", $op, $self->to_string($expr);
+}
+
+sub _to_string_interval {
+  my ($self, $expr, $unit) = @_;
+  sprintf "INTERVAL %s %s", $self->to_string($expr), $unit;
+}
+
+sub _to_string_alias {
+  my ($self, $alias, $expr) = @_;
+
+  sprintf "%s AS %s", $self->to_string($expr), $self->quote_identifier($alias);
+}
+
+sub _to_string_inop {
+  my ($self, $op, $expr, $exprs) = @_;
+  sprintf "%s %s (%s)", $self->to_string($expr), uc $op,
+    join(", ", map { $self->to_string($_) } @$exprs);
+}
+
+sub _to_string_case {
+  my ($self, $value, $conds) = @_;
+
+  'CASE '
+    . $self->to_string($value) . ' '
+    . join(' ', map { $self->to_string($_) } @$conds) . ' END';
+}
+
+sub _to_string_when {
+  my ($self, $compare, $result) = @_;
+
+  'WHEN ' . $self->to_string($compare) . ' THEN ' . $self->to_string($result);
+}
+
+sub _to_string_else {
+  my ($self, $result) = @_;
+
+  'ELSE ' . $self->to_string($result);
+}
+
+sub _to_string_between {
+  my ($self, $val, $min, $max) = @_;
+
+  sprintf "%s BETWEEN %s AND %s", $self->to_string($val), $self->to_string($min),
+    $self->to_string($max);
 }
 
 1;

--- a/Bugzilla/DB/QuoteIdentifier.pm
+++ b/Bugzilla/DB/QuoteIdentifier.pm
@@ -10,11 +10,7 @@ package Bugzilla::DB::QuoteIdentifier;
 use 5.10.1;
 use Moo;
 
-has 'db' => (
-  is       => 'ro',
-  weak_ref => 1,
-  required => 1,
-);
+has 'db' => (is => 'ro', weak_ref => 1, required => 1,);
 
 sub TIEHASH {
   my ($class, @args) = @_;
@@ -37,11 +33,11 @@ sub FIRSTVALUE {
 }
 
 sub EXISTS {
-  return 1
+  return 1;
 }
 
 sub DELETE {
-  return 1
+  return 1;
 }
 
 1;

--- a/Bugzilla/User.pm
+++ b/Bugzilla/User.pm
@@ -1687,6 +1687,7 @@ sub derive_regexp_groups {
   return unless $id;
 
   my $dbh = Bugzilla->dbh;
+  my $q   = $dbh->qi;
 
   my $sth;
 
@@ -1694,7 +1695,7 @@ sub derive_regexp_groups {
 
   $sth = $dbh->prepare(
     "SELECT id, userregexp, user_group_map.group_id
-                            FROM groups
+                            FROM $q->{groups}
                        LEFT JOIN user_group_map
                               ON groups.id = user_group_map.group_id
                              AND user_group_map.user_id = ?

--- a/t/800quote_identifier.t
+++ b/t/800quote_identifier.t
@@ -1,0 +1,129 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use 5.10.1;
+use Test2::V0;
+use File::Spec::Functions qw(catdir);
+use File::Basename qw(dirname);
+use Package::Stash;
+
+use lib catdir(dirname(__FILE__), '..');
+
+use ok 'Bugzilla::DB::Mysql';
+use ok 'Bugzilla::DB::Pg';
+use ok 'Bugzilla::DB::Sqlite';
+use ok 'Bugzilla::DB';
+use ok 'Bugzilla::DB::QuoteIdentifier';
+
+my %sql_method_test = (
+  sql_iposition => sub {
+    my ($dbh, $parse) = @_;
+    ok(lives { $parse->($dbh->sql_iposition('?', 'login_name')) },
+      "sql_iposition is parseable")
+      or note($@);
+  },
+  sql_position => sub {
+    my ($dbh, $parse) = @_;
+    ok(lives { $parse->($dbh->sql_position(q{'\n'}, 'thetext') . q{ > 81 }) },
+      "sql_position is parseable")
+      or note($@);
+  },
+  sql_string_concat => sub {
+    my ($dbh, $parse) = @_;
+    ok(
+      lives {
+        $parse->($dbh->sql_string_concat('map_flagtypes.name', 'map_flags.status'))
+      },
+      "sql_string_concat is parseable"
+    ) or note($@);
+  },
+  sql_date_format => sub {
+    my ($dbh, $parse) = @_;
+    ok(lives { $parse->($dbh->sql_date_format('bugs.deadline', '%Y-%m-%d')) },
+      "sql_date_format is parseable")
+      or note($@);
+  },
+  sql_date_math => sub {
+    my ($dbh, $parse) = @_;
+    ok(lives { $parse->($dbh->sql_date_math('NOW()', '-', 30, 'MINUTE')) },
+      "sql_date_math NOW() - 30 MINUTE")
+      or note($@);
+  },
+  sql_to_days => sub {
+    my ($dbh, $parse) = @_;
+    ok(lives { $parse->($dbh->sql_to_days('bugs_activity.bug_when')) },
+      "sql_to_days is parseable")
+      or note($@);
+  },
+  sql_from_days => sub {
+    my ($dbh, $parse) = @_;
+    ok(lives { $parse->($dbh->sql_from_days(42)) },
+      "sql_from_days is parseable")
+      or note($@);
+  },
+  sql_regexp => sub {
+    my ($dbh, $parse) = @_;
+    ok(lives { $parse->($dbh->sql_regexp('profiles.login_name', q{'@'})) },
+      "sql_regexp is parseable")
+      or note($@);
+  },
+  sql_not_regexp => sub {
+    my ($dbh, $parse) = @_;
+    ok(lives { $parse->($dbh->sql_not_regexp('profiles.login_name', q{'@'})) },
+      "sql_not_regexp is parseable")
+      or note($@);
+  },
+  sql_istring => sub {
+    my ($dbh, $parse) = @_;
+    ok(lives { $parse->($dbh->sql_istring('profiles.login_name')) },
+      "sql_istring is parseable")
+      or note($@);
+  },
+  sql_limit => sub {
+    note("sql_limit is not expression, not tested.");
+  },
+  sql_group_by => sub {
+    note("sql_group_by is not expression, not tested.");
+  },
+);
+
+
+my $mysql_stash = Package::Stash->new('Bugzilla::DB::Mysql');
+my $mysql_mock  = mock 'Bugzilla::DB::Mysql' => (
+  add_constructor => ['new_fake' => 'hash'],
+  override        => [
+    bz_check_regexp => sub { },
+    quote => sub {
+      my (undef, $s) = @_;
+      $s =~ s/'/\\'/gs;
+      return "'$s'";
+    },
+    quote_identifier => sub {
+      my (undef, $s) = @_;
+      return "`$s`";
+    },
+  ]
+);
+my $mysql       = Bugzilla::DB::Mysql->new_fake;
+my $mysql_parse = sub {
+  state $parser = Bugzilla::DB::QuoteIdentifier->new(
+    db                        => $mysql,
+    sql_identifier_quote_char => '`'
+  );
+  my $sql = $parser->to_string($parser->from_string($_[0]));
+  note("IN:  $_[0]\nOUT: $sql\n");
+  $sql;
+};
+
+my @sql_methods = sort grep {/^sql_/} $mysql_stash->list_all_symbols('CODE');
+
+foreach my $method (@sql_methods) {
+  if (my $test = $sql_method_test{$method}) {
+    $test->($mysql, $mysql_parse);
+  }
+  else {
+    fail("No test for $method");
+  }
+}
+
+done_testing;


### PR DESCRIPTION
This patch improves `Bugzilla::DB::QuoteIdentifier` so that it can parse and quote most SQL expressions (and all expressions that bugzilla uses).

This means *every* bare word is quoted, even when we don't need to. This is easier than worrying about which keywords MySQL has forbidden to make their parser simpler (and/or more decideable)

The goal here is to not make a larger diff than required.