### PR TITLE
Mailing list splitting extension

### DIFF
--- a/extensions/OpenLDAPSec/Config.pm
+++ b/extensions/OpenLDAPSec/Config.pm
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::OpenLDAPSec;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use constant NAME => 'OpenLDAPSec';
+
+use constant REQUIRED_MODULES => [
+];
+
+use constant OPTIONAL_MODULES => [
+];
+
+__PACKAGE__->NAME;

--- a/extensions/OpenLDAPSec/Extension.pm
+++ b/extensions/OpenLDAPSec/Extension.pm
@@ -1,0 +1,63 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::OpenLDAPSec;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use parent qw(Bugzilla::Extension);
+
+# This code for this is in ../extensions/OpenLDAPSec/lib/Util.pm
+use Bugzilla::Extension::OpenLDAPSec::Util;
+
+use Bugzilla::Util;
+use Bugzilla::Constants;
+
+use List::MoreUtils qw(any);
+
+our $VERSION = '0.01';
+
+# CC the appropriate lists:
+# - public list for public bugs
+# - insiders if it's a private bug or a private comment is in the mail
+sub bugmail_recipients {
+    my ($self, $args) = @_;
+    my $recipients = $args->{recipients};
+    my $bug        = $args->{bug};
+
+    my $insider_group = new Bugzilla::Group({name => Bugzilla->params->{'insidergroup'}});
+
+    my $insider_list = new Bugzilla::User({name => Bugzilla->params->{'insider_list'}});
+    my $public_list = new Bugzilla::User({name => Bugzilla->params->{'public_list'}});
+
+    return unless ( defined $insider_group && defined $insider_list && defined $public_list );
+
+    if ( any { $_->id eq $insider_group->id } @{$bug->groups_in} ) {
+        delete $recipients->{$public_list->id};
+        $recipients->{$insider_list->id}->{+REL_CC} = 2;
+    } else {
+        # It's a public bug, add public list, it still won't get private comments
+        $recipients->{$public_list->id}->{+REL_CC} = 2;
+
+        # Is there a private comment? If so, add insider_list on CC
+        my $comments = $bug->comments({after => $bug->lastdiffed, to => $bug->delta_ts});
+        @$comments = grep { $_->type || $_->body =~ /\S/ } @$comments;
+        if ( any { $_->is_private } @$comments ) {
+            $recipients->{$insider_list->id}->{+REL_CC} = 2;
+        }
+    }
+}
+
+sub config_add_panels {
+    my ($self, $args) = @_;
+    my $modules = $args->{panel_modules};
+    $modules->{OpenLDAPSec} = "Bugzilla::Extension::OpenLDAPSec::Config";
+}
+
+__PACKAGE__->NAME;

--- a/extensions/OpenLDAPSec/docs/en/rst/index-admin.rst
+++ b/extensions/OpenLDAPSec/docs/en/rst/index-admin.rst
@@ -1,0 +1,10 @@
+OpenLDAPSec
+###########
+
+This is a sample Adminstrator documentation file for the OpenLDAPSec extension.
+Like all of the Bugzilla docs, it's written in
+`reStructured Text (reST) format <http://sphinx-doc.org/latest/rest.html>`_
+and will be compiled by `Sphinx <http://sphinx-doc.org/>`_.
+
+If you build the docs yourself using :file:`makedocs.pl`, this file will get
+incorporated into the Installed Extensions chapter of the Administration Guide.

--- a/extensions/OpenLDAPSec/docs/en/rst/index-user.rst
+++ b/extensions/OpenLDAPSec/docs/en/rst/index-user.rst
@@ -1,0 +1,10 @@
+OpenLDAPSec
+###########
+
+This is a sample User documentation file for the OpenLDAPSec extension.
+Like all of the Bugzilla docs, it's written in
+`reStructured Text (reST) format <http://sphinx-doc.org/latest/rest.html>`_
+and will be compiled by `Sphinx <http://sphinx-doc.org/>`_.
+
+If you build the docs yourself using :file:`makedocs.pl`, this file will get
+incorporated into the Installed Extensions chapter of the User Guide.

--- a/extensions/OpenLDAPSec/lib/Config.pm
+++ b/extensions/OpenLDAPSec/lib/Config.pm
@@ -1,0 +1,82 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::OpenLDAPSec::Config;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use Bugzilla::Config::Common;
+use Bugzilla::Constants;
+
+our $sortkey = 5000;
+
+sub get_param_list {
+    my ($class) = @_;
+
+    my @params = (
+        {
+            name    => 'public_list',
+            type    => 's',
+            choices => \&_get_disabled_users,
+            default => '',
+            checker => \&_check_disabled_user
+        },
+        {
+            name    => 'insider_list',
+            type    => 's',
+            choices => \&_get_disabled_insiders,
+            default => '',
+            checker => \&_check_insider_user
+        },
+    );
+
+    return @params;
+}
+
+sub _get_disabled_users {
+    my $search = Bugzilla::Object::match('Bugzilla::User', {is_enabled => 0});
+    my @user_names = map { $_->login } @$search;
+    unshift(@user_names, '');
+    return \@user_names;
+}
+
+sub _check_disabled_user {
+    my $login = shift;
+    return "" unless $login;
+    my $user = new Bugzilla::User({'name' => $login});
+    unless (defined $user) {
+        return "Must be an existing user name";
+    }
+    unless ($user->disabledtext) {
+        return "Must be a disabled user";
+    }
+    return "";
+}
+
+sub _get_disabled_insiders {
+    my $search = Bugzilla::Object::match('Bugzilla::User', {is_enabled => 0});
+    my @user_names = map { $_->login } grep { $_->is_insider } @$search;
+    unshift(@user_names, '');
+    return \@user_names;
+}
+
+sub _check_insider_user {
+    my $login = shift;
+    return "" unless $login;
+    my $user = new Bugzilla::User({'name' => $login});
+    unless (defined $user) {
+        return "Must be an existing user name";
+    }
+    unless ($user->disabledtext && $user->is_insider) {
+        return "Must be a disabled member of the insiders group";
+    }
+    return "";
+}
+
+1;

--- a/extensions/OpenLDAPSec/lib/Util.pm
+++ b/extensions/OpenLDAPSec/lib/Util.pm
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+package Bugzilla::Extension::OpenLDAPSec::Util;
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use parent qw(Exporter);
+our @EXPORT = qw(
+    
+);
+
+# This file can be loaded by your extension via 
+# "use Bugzilla::Extension::OpenLDAPSec::Util". You can put functions
+# used by your extension in here. (Make sure you also list them in
+# @EXPORT.)
+
+1;

--- a/extensions/OpenLDAPSec/template/en/default/admin/params/openldapsec.html.tmpl
+++ b/extensions/OpenLDAPSec/template/en/default/admin/params/openldapsec.html.tmpl
@@ -1,0 +1,19 @@
+[%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  #
+  # This Source Code Form is "Incompatible With Secondary Licenses", as
+  # defined by the Mozilla Public License, v. 2.0.
+  #%]
+
+[%
+   title = "Mailing lists"
+   desc = "Configure OpenLDAP Mailing lists"
+%]
+
+[%
+   param_descs = {
+       public_list  => "Public list email",
+       insider_list => "Security list email"
+   }
+%]

--- a/extensions/OpenLDAPSec/template/en/default/hook/README
+++ b/extensions/OpenLDAPSec/template/en/default/hook/README
@@ -1,0 +1,5 @@
+Template hooks go in this directory. Template hooks are called in normal
+Bugzilla templates like [% Hook.process('some-hook') %].
+More information about them can be found in the documentation of 
+Bugzilla::Extension. (Do "perldoc Bugzilla::Extension" from the main
+Bugzilla directory to see that documentation.)

--- a/extensions/OpenLDAPSec/template/en/default/openldapsec/README
+++ b/extensions/OpenLDAPSec/template/en/default/openldapsec/README
@@ -1,0 +1,16 @@
+Normal templates go in this directory. You can load them in your
+code like this:
+
+use Bugzilla::Error;
+my $template = Bugzilla->template;
+$template->process('openldapsec/some-template.html.tmpl')
+  or ThrowTemplateError($template->error());
+
+That would be how to load a file called <kbd>some-template.html.tmpl</kbd> that
+was in this directory.
+
+Note that you have to be careful that the full path of your template
+never conflicts with a template that exists in Bugzilla or in 
+another extension, or your template might override that template. That's why
+we created this directory called 'openldapsec' for you, so you
+can put your templates in here to help avoid conflicts.

--- a/extensions/OpenLDAPSec/web/README
+++ b/extensions/OpenLDAPSec/web/README
@@ -1,0 +1,7 @@
+Web-accessible files, like JavaScript, CSS, and images go in this
+directory. You can reference them directly in your HTML. For example,
+if you have a file called "style.css" and your extension is called
+"Foo", you would put it in "extensions/Foo/web/style.css", and then
+you could link to it in HTML like:
+
+<link href="extensions/Foo/web/style.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Draft PR for openldap.org extension to solicit feedback and eventual adoption if possible:

Maintains two lists:
- public archive of bugzilla traffic
- private list for sensitive activity

Each message leaving bugzilla will be CC'd onto either of them, private
list will be used for private bugs or private comments, public list
for all else to keep the private list traffic at sane levels.