### PR TITLE
Remove Landfill reference

### DIFF
--- a/README
+++ b/README
@@ -7,7 +7,7 @@ by thousands of projects and companies around the world. It can be installed on
 Linux and other flavors of Unix, Windows or Mac OS X.
 
 You can try Bugzilla out using our testing installation:
-https://landfill.bugzilla.org/bugzilla-tip/
+https://bugzilla-dev.allizom.org/
 
 Documentation
 =============

--- a/README
+++ b/README
@@ -6,9 +6,6 @@ developed by an active group of volunteers in the Mozilla community, and used
 by thousands of projects and companies around the world. It can be installed on
 Linux and other flavors of Unix, Windows or Mac OS X.
 
-You can try Bugzilla out using our testing installation:
-https://bugzilla-dev.allizom.org/
-
 Documentation
 =============
 

--- a/contrib/bugzilla-submit/README
+++ b/contrib/bugzilla-submit/README
@@ -20,7 +20,7 @@ Usage Notes
 -----------
 
 * Please constrain testing to your own installation of Bugzilla, or use
-* http://landfill.bugzilla.org/ for testing purposes -- opening test
+* https://bugzilla-dev.allizom.org/ for testing purposes -- opening test
 * bugs on production instances of Bugzilla is definitely not a good idea
 
 Run "bugzilla-submit --help" for a description of the possible options.

--- a/contrib/bugzilla-submit/README
+++ b/contrib/bugzilla-submit/README
@@ -19,9 +19,8 @@ Its only requirement is Python 2.3 or higher; you should have the
 Usage Notes
 -----------
 
-* Please constrain testing to your own installation of Bugzilla, or use
-* https://bugzilla-dev.allizom.org/ for testing purposes -- opening test
-* bugs on production instances of Bugzilla is definitely not a good idea
+* Please constrain testing to your own installation of Bugzilla, opening test
+* bugs on production instances of Bugzilla is definitely not a good idea.
 
 Run "bugzilla-submit --help" for a description of the possible options.
 

--- a/contrib/bugzilla-submit/bugzilla-submit.xml
+++ b/contrib/bugzilla-submit/bugzilla-submit.xml
@@ -201,12 +201,12 @@ password field is the right password.  The URL in the machine field
 must be enclosed in double quotes.</para>
 
 <para>For example, if your Bugzilla instance is at
-"http://landfill.bugzilla.org/bztest/", and your login and password
+"https://bugzilla-dev.allizom.org/bztest/", and your login and password
 there are "john@doe.com" and "foo", respectively, your
 <filename>.netrc</filename> entry should look something like:</para>
 
 <screen>
-    machine "http://landfill.bugzilla.org/bztest/"
+    machine "https://bugzilla-dev.allizom.org/bztest/"
     login john@doe.com
     password foo
 

--- a/contrib/bugzilla-submit/bugzilla-submit.xml
+++ b/contrib/bugzilla-submit/bugzilla-submit.xml
@@ -201,12 +201,12 @@ password field is the right password.  The URL in the machine field
 must be enclosed in double quotes.</para>
 
 <para>For example, if your Bugzilla instance is at
-"https://bugzilla-dev.allizom.org/bztest/", and your login and password
+"https://bugzilla.example.org/bztest/", and your login and password
 there are "john@doe.com" and "foo", respectively, your
 <filename>.netrc</filename> entry should look something like:</para>
 
 <screen>
-    machine "https://bugzilla-dev.allizom.org/bztest/"
+    machine "https://bugzilla.example.org/bztest/"
     login john@doe.com
     password foo
 

--- a/docs/en/rst/about/index.rst
+++ b/docs/en/rst/about/index.rst
@@ -17,11 +17,9 @@ The most current version of this document can always be found on the
 Evaluating Bugzilla
 ###################
 
-If you want to try out Bugzilla to see if it meets your needs, you can do so
-on `Landfill <https://landfill.bugzilla.org/bugzilla-4.4-branch/>`_, our test
-server. The `Bugzilla FAQ <https://wiki.mozilla.org/Bugzilla:FAQ>`_ may also
-be helpful, as it answers a number of questions people sometimes have about
-whether Bugzilla is for them.
+The `Bugzilla FAQ <https://wiki.mozilla.org/Bugzilla:FAQ>`_ may be helpful, 
+as it answers a number of questions people sometimes have about whether 
+Bugzilla is for them.
 
 .. _getting-help:
 

--- a/docs/en/rst/using/creating-an-account.rst
+++ b/docs/en/rst/using/creating-an-account.rst
@@ -7,7 +7,7 @@ If you want to use a particular installation of Bugzilla, first you need to
 create an account. Ask the administrator responsible for your installation
 for the URL you should use to access it. If you're test-driving Bugzilla,
 you can use one of the installations on
-`Landfill <http://landfill.bugzilla.org/>`_.
+`Landfill <https://bugzilla-dev.allizom.org/>`_.
 
 The process of creating an account is similar to many other websites.
 

--- a/docs/en/rst/using/creating-an-account.rst
+++ b/docs/en/rst/using/creating-an-account.rst
@@ -5,9 +5,7 @@ Creating an Account
 
 If you want to use a particular installation of Bugzilla, first you need to
 create an account. Ask the administrator responsible for your installation
-for the URL you should use to access it. If you're test-driving Bugzilla,
-you can use one of the installations on
-`Landfill <https://bugzilla-dev.allizom.org/>`_.
+for the URL you should use to access it.
 
 The process of creating an account is similar to many other websites.
 

--- a/docs/en/rst/using/filing.rst
+++ b/docs/en/rst/using/filing.rst
@@ -8,7 +8,7 @@ Reporting a New Bug
 
 Years of bug writing experience has been distilled for your
 reading pleasure into the
-`Bug Writing Guidelines <http://landfill.bugzilla.org/bugzilla-tip/page.cgi?id=bug-writing.html>`_.
+`Bug Writing Guidelines <https://developer.mozilla.org/en-US/docs/Mozilla/QA/Bug_writing_guidelines>`_.
 While some of the advice is Mozilla-specific, the basic principles of
 reporting Reproducible, Specific bugs and isolating the Product you are
 using, the Version of the Product, the Component which failed, the Hardware
@@ -17,7 +17,7 @@ long way toward ensuring accurate, responsible fixes for the bug that bit you.
 
 .. note:: If you want to file a test bug to see how Bugzilla works,
    you can do it on one of our test installations on
-   `Landfill <http://landfill.bugzilla.org/>`_. Please don't do it on anyone's
+   `Landfill <https://bugzilla-dev.allizom.org/>`_. Please don't do it on anyone's
    production Bugzilla installation.
 
 The procedure for filing a bug is as follows:

--- a/docs/en/rst/using/filing.rst
+++ b/docs/en/rst/using/filing.rst
@@ -15,11 +15,6 @@ using, the Version of the Product, the Component which failed, the Hardware
 Platform, and Operating System you were using at the time of the failure go a
 long way toward ensuring accurate, responsible fixes for the bug that bit you.
 
-.. note:: If you want to file a test bug to see how Bugzilla works,
-   you can do it on one of our test installations on
-   `Landfill <https://bugzilla-dev.allizom.org/>`_. Please don't do it on anyone's
-   production Bugzilla installation.
-
 The procedure for filing a bug is as follows:
 
 #. Click the :guilabel:`New` link available in the header or footer

--- a/docs/en/rst/using/finding.rst
+++ b/docs/en/rst/using/finding.rst
@@ -43,8 +43,7 @@ Advanced Search
 ===============
 
 The Advanced Search page is used to produce a list of all bugs fitting
-exact criteria. `You can play with it on
-Landfill <http://landfill.bugzilla.org/bugzilla-tip/query.cgi?format=advanced>`_.
+exact criteria.
 
 Advanced Search has controls for selecting different possible
 values for all of the fields in a bug, as described above. For some


### PR DESCRIPTION
This PR updates the test playground reference to the current URL as Landfill no longer works. 