### PR TITLE
Add mysql_ssl_optional parameter to allow relaxed SSL connections

### DIFF
--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -61,16 +61,17 @@ sub new {
   );
 
   # MySQL SSL options
-  my ($ssl_ca_file, $ssl_ca_path, $ssl_cert, $ssl_key) = @$params{
+  my ($ssl_ca_file, $ssl_ca_path, $ssl_cert, $ssl_key, $ssl_optional) = @$params{
     qw(db_mysql_ssl_ca_file db_mysql_ssl_ca_path
-      db_mysql_ssl_client_cert db_mysql_ssl_client_key)
+      db_mysql_ssl_client_cert db_mysql_ssl_client_key db_mysql_ssl_optional)
   };
-  if ($ssl_ca_file || $ssl_ca_path || $ssl_cert || $ssl_key) {
+  if ($ssl_ca_file || $ssl_ca_path || $ssl_cert || $ssl_key || $ssl_optional) {
     $attrs{'mysql_ssl'}             = 1;
     $attrs{'mysql_ssl_ca_file'}     = $ssl_ca_file if $ssl_ca_file;
     $attrs{'mysql_ssl_ca_path'}     = $ssl_ca_path if $ssl_ca_path;
     $attrs{'mysql_ssl_client_cert'} = $ssl_cert if $ssl_cert;
     $attrs{'mysql_ssl_client_key'}  = $ssl_key if $ssl_key;
+    $attrs{'mysql_ssl_optional'}    = $ssl_optional if $ssl_optional;
   }
 
   my $self = $class->db_new(

--- a/Bugzilla/Install/Localconfig.pm
+++ b/Bugzilla/Install/Localconfig.pm
@@ -51,6 +51,7 @@ use constant LOCALCONFIG_VARS => (
   {name => 'db_mysql_ssl_ca_path',     default => '',},
   {name => 'db_mysql_ssl_client_cert', default => '',},
   {name => 'db_mysql_ssl_client_key',  default => '',},
+  {name => 'db_mysql_ssl_optional',    default => '',},
   {name => 'index_html',               default => 0,},
   {name => 'interdiffbin',             default => sub { bin_loc('interdiff') },},
   {name => 'diffpath', default => sub { dirname(bin_loc('diff')) },},

--- a/template/en/default/setup/strings.txt.pl
+++ b/template/en/default/setup/strings.txt.pl
@@ -215,9 +215,9 @@ which don't do strict checking by default. This can be helpful with MySQL/MariaD
 systems using self-signed certificates or with Amazon RDS instances which don't have
 their Root CA's published in the OS supplied CA bundles.
 
-If this is set to 1 (which is default if left blank), strict SSL checking will be enabled.
+If this is set to 0 (which is default if left blank), strict SSL checking will be enabled.
 
-If this is set to 0, strict SSL checking will be disabled.
+If this is set to 1, strict SSL checking will be disabled.
 END
   localconfig_diffpath => <<'END',
 For the "Difference Between Two Patches" feature to work, we need to know

--- a/template/en/default/setup/strings.txt.pl
+++ b/template/en/default/setup/strings.txt.pl
@@ -208,6 +208,17 @@ END
 Full path to the private key corresponding to the client SSL certificate.
 The file must not be password-protected and must be readable by web server user.
 END
+  localconfig_db_mysql_ssl_optional => <<'END',
+Allows relaxing of strict SSL enforcement for the server SSL certificate checks.
+This aligns more with the default behavior of the MySQL/MariaDB client applications
+which don't do strict checking by default. This can be helpful with MySQL/MariaDB 
+systems using self-signed certificates or with Amazon RDS instances which don't have
+their Root CA's published in the OS supplied CA bundles.
+
+If this is set to 1 (which is default if left blank), strict SSL checking will be enabled.
+
+If this is set to 0, strict SSL checking will be disabled.
+END
   localconfig_diffpath => <<'END',
 For the "Difference Between Two Patches" feature to work, we need to know
 what directory the "diff" bin is in. (You only need to set this if you


### PR DESCRIPTION
Added an additional MySQL parameter to permit relaxing the strict SSL enforcement done by perl::DBD::MySQL. Permits behavior similar to the default --ssl option for MariaDB clients and --ssl-mode=REQUIRED and --ssl-mode=PREFERRED for MySQL clients.