### PR TITLE
Bug 1785938: Make tests work in GHA on 5.0.4 branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+#### Details
+<!-- Explain what you did -->
+This PR fixes/adds a feature...
+
+#### Additional info
+* [bmo#](https://bugzilla.mozilla.org/show_bug.cgi?id=)
+
+#### Test Plan
+<!-- How did you verify the fix/feature in steps -->
+1. Open the show_bug view
+2. Edit the bug
+3. ...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Release Tests
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the main branch
+on:
+  push:
+    branches: [ 5.0.4 ]
+  pull_request:
+    branches: [ 5.0.4 ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  ubuntu:
+    name: Release Tests on Ubuntu 20.04
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: apt install
+        run: |
+          sudo apt-get update
+          sudo apt-get -y dist-upgrade
+          sudo apt-get install --ignore-hold --allow-downgrades -y \
+          apache2 \
+          mariadb-client-10.3 \
+          netcat \
+          libappconfig-perl \
+          libdate-calc-perl \
+          libtemplate-perl \
+          build-essential \
+          libdatetime-timezone-perl \
+          libdatetime-perl \
+          libemail-address-perl \
+          libemail-sender-perl \
+          libemail-mime-perl \
+          libemail-mime-modifier-perl \
+          libdbi-perl \
+          libdbix-connector-perl \
+          libdbd-mysql-perl \
+          libcgi-pm-perl \
+          libmath-random-isaac-perl \
+          libmath-random-isaac-xs-perl \
+          libapache2-mod-perl2 \
+          libapache2-mod-perl2-dev \
+          libchart-perl \
+          libxml-perl \
+          libxml-twig-perl \
+          perlmagick \
+          libgd-graph-perl \
+          libtemplate-plugin-gd-perl \
+          libsoap-lite-perl \
+          libhtml-scrubber-perl \
+          libjson-rpc-perl \
+          libdaemon-generic-perl \
+          libtheschwartz-perl \
+          libtest-taint-perl \
+          libauthen-radius-perl \
+          libfile-slurp-perl \
+          libencode-detect-perl \
+          libmodule-build-perl \
+          libnet-ldap-perl \
+          libauthen-sasl-perl \
+          libfile-mimeinfo-perl \
+          libhtml-formattext-withlinks-perl \
+          libpod-coverage-perl \
+          graphviz
+      - name: Get Perl Version and debug info
+        run: '/usr/bin/perl -V'
+      - name: Run tests
+        run: '/usr/bin/perl runtests.pl'

--- a/t/002goodperl.t
+++ b/t/002goodperl.t
@@ -14,7 +14,7 @@ use 5.10.1;
 use strict;
 use warnings;
 
-use lib 't';
+use lib qw(. lib t);
 
 use Support::Files;
 

--- a/t/003safesys.t
+++ b/t/003safesys.t
@@ -14,7 +14,7 @@ use 5.10.1;
 use strict;
 use warnings;
 
-use lib 't';
+use lib qw(. lib t);
 
 use Support::Files;
 

--- a/t/004template.t
+++ b/t/004template.t
@@ -13,7 +13,7 @@ use 5.10.1;
 use strict;
 use warnings;
 
-use lib 't';
+use lib qw(. lib t);
 
 use Support::Templates;
 

--- a/t/005whitespace.t
+++ b/t/005whitespace.t
@@ -13,7 +13,7 @@ use 5.10.1;
 use strict;
 use warnings;
 
-use lib 't';
+use lib qw(. lib t);
 
 use Support::Files;
 use Support::Templates;

--- a/t/006spellcheck.t
+++ b/t/006spellcheck.t
@@ -14,7 +14,7 @@ use 5.10.1;
 use strict;
 use warnings;
 
-use lib 't';
+use lib qw(. lib t);
 use Support::Files;
 
 # -1 because 006spellcheck.t must not be checked.

--- a/t/007util.t
+++ b/t/007util.t
@@ -13,7 +13,7 @@ use 5.10.1;
 use strict;
 use warnings;
 
-use lib 't';
+use lib qw(. lib t);
 use Support::Files;
 use Test::More tests => 17;
 use DateTime;

--- a/t/009bugwords.t
+++ b/t/009bugwords.t
@@ -19,7 +19,7 @@ use 5.10.1;
 use strict;
 use warnings;
 
-use lib 't';
+use lib qw(. t lib);
 
 use Support::Files;
 use Support::Templates;

--- a/t/010dependencies.t
+++ b/t/010dependencies.t
@@ -69,7 +69,7 @@ foreach my $module (keys %mods) {
             $used =~ s#/#::#g;
             $used =~ s#\.pm$##;
             $used =~ s#\$module#[^:]+#;
-            $used =~ s#\${[^}]+}#[^:]+#;
+            $used =~ s#\$\{[^}]+\}#[^:]+#;
             $used =~ s#[" ]##g;
             push(@use, grep(/^\Q$used\E$/, keys %mods));
         }

--- a/t/011pod.t
+++ b/t/011pod.t
@@ -14,7 +14,7 @@ use 5.10.1;
 use strict;
 use warnings;
 
-use lib 't';
+use lib qw(. lib t);
 
 use Support::Files;
 use Pod::Checker;


### PR DESCRIPTION
* Adds GitHub Actions to run tests
* Fixes tests for compatibility with Perl 5.30

Note: Tests currently have a legitimate test failure (pod coverage) which will need a separate patch on a new bug to fix.