### PR TITLE
Move Directory out of VirtualHost (5.2)

### DIFF
--- a/docs/en/rst/installing/quick-start.rst
+++ b/docs/en/rst/installing/quick-start.rst
@@ -107,17 +107,16 @@ Configure Apache
 Paste in the following and save:
 
 .. code-block:: apache
-
- <VirtualHost \*:80>
-   ServerName localhost
-
    <Directory /var/www/html/bugzilla>
      AddHandler cgi-script .cgi
      Options +ExecCGI
      DirectoryIndex index.cgi index.html
      AllowOverride All
    </Directory>
- </VirtualHost>
+
+   <VirtualHost *:80>
+     ServerName localhost
+   </VirtualHost>
 
 :command:`a2ensite bugzilla`
 


### PR DESCRIPTION
#### Details
This PR fixes an issue with documentation, where settings didn't apply to addresses not mentioned in VirtualHost

#### Additional info
* [bmo#1797108](https://bugzilla.mozilla.org/show_bug.cgi?id=1797108)