### PR TITLE
[master, 5.1.x] Bug 1657496: correctly handle MIME type on single-part email

### DIFF
--- a/Bugzilla/Mailer.pm
+++ b/Bugzilla/Mailer.pm
@@ -77,10 +77,10 @@ sub generate_email {
   }
 
   my $email = Bugzilla::MIME->new($msg_header);
-  if (scalar(@parts) == 1) {
-    $email->content_type_set($parts[0]->content_type);
-  }
-  else {
+
+  # If there's only one part, we don't need to set the overall content type
+  # because Email::MIME will automatically take it from that part (bug 1657496)
+  if (scalar(@parts) > 1) {
     $email->content_type_set('multipart/alternative');
 
     # Some mail clients need same encoding for each part, even empty ones.


### PR DESCRIPTION
Backported from 6765ab04774eebf8ea0bd063566240b24ac28f15.

#### Details
This is a backport of 6765ab04774eebf8ea0bd063566240b24ac28f15 to master for future 5.1.x releases.
The original patch doesn't apply because of the following 2 commits:
6638a0154878 ("Bug 1105568: Add support for HTML flagmail r=glob,a=glob")
425158e8c96c ("no bug - reformat all the code using the new perltidy rules")

#### Additional info
https://bugzilla.mozilla.org/show_bug.cgi?id=1657496

#### Test Plan
I created a new bug, and made sure the following error is no longer reported once I hit `Submit Bug` while `Default Preferences -> Preferred email format` is set to plain:
```
Software error:
Invalid Content-Type 'subtype' parameter at Bugzilla/Mailer.pm line 80.
```