### PR TITLE
bug 1817837 - improve the wording of the "summary" help

### DIFF
--- a/template/en/default/bug/create/create-guided.html.tmpl
+++ b/template/en/default/bug/create/create-guided.html.tmpl
@@ -228,8 +228,7 @@ function PutDescription() {
       </p>
       <p>
         <kbd>
-          <span class="bad">Bad example</span>: Mozilla crashed.
-          You suck!
+          <span class="bad">Bad example</span>: Firefox crashed. Too bad!
         </kbd>
         <br>
         <kbd>


### PR DESCRIPTION
[bmo#1817837](https://bugzilla.mozilla.org/show_bug.cgi?id=1817837)
