### PR TITLE
Bug 1839072: fix Apache config not showing in quickstart docs

### DIFF
--- a/docs/en/rst/installing/quick-start.rst
+++ b/docs/en/rst/installing/quick-start.rst
@@ -103,6 +103,7 @@ Configure Apache
 Paste in the following and save:
 
 .. code-block:: apache
+
  Alias /bugzilla /var/www/webapps/bugzilla
  <Directory /var/www/webapps/bugzilla>
    AddHandler cgi-script .cgi


### PR DESCRIPTION
#### Details
The apache code block directive in RST needs a blank line after it before the code starts.

#### Additional info
* [bmo#1839072](https://bugzilla.mozilla.org/show_bug.cgi?id=1839072)
