### PR TITLE
[5.1] Bug 1851354: blocklist MySQL 8+, offer MariaDB

### DIFF
--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -540,7 +540,16 @@ use constant INSTALLATION_MODE_NON_INTERACTIVE => 1;
 use constant DB_MODULE => {
 
   # MySQL 5.0.15 was the first production 5.0.x release.
-  mysql => {db => 'Bugzilla::DB::Mysql', db_version => '5.0.15', name => 'MySQL'},
+  # We blacklist MySQL 8.0 and newer, and explicitly list MariaDB as an
+  # alternative. The db_blklst_str is shown in the auto-generated release notes
+  # instead of the regexp. We can't tell Maria apart from MySQL in our check
+  # and MariaDB skipped versions from 5 to 10, so we'll blacklist 8 and 9 for
+  # MariaDB as well just in case someone configured for 'mariadb' but actually
+  # has MySQL installed. See https://bugzilla.mozilla.org/show_bug.cgi?id=1851354
+  mysql => {db => 'Bugzilla::DB::Mysql', db_version => '5.0.15', name => 'MySQL',
+            db_blacklist => ['^[89]\.'], db_blklst_str => '>= 8.0'},
+  mariadb => {db => 'Bugzilla::DB::Mysql', db_version => '5.1', name => 'MariaDB',
+            db_blacklist => ['^[89]\.']},
   pg =>
     {db => 'Bugzilla::DB::Pg', db_version => '9.00.0000', name => 'PostgreSQL'},
   oracle =>

--- a/Bugzilla/Constants.pm
+++ b/Bugzilla/Constants.pm
@@ -540,16 +540,16 @@ use constant INSTALLATION_MODE_NON_INTERACTIVE => 1;
 use constant DB_MODULE => {
 
   # MySQL 5.0.15 was the first production 5.0.x release.
-  # We blacklist MySQL 8.0 and newer, and explicitly list MariaDB as an
+  # We blocklist MySQL 8.0 and newer, and explicitly list MariaDB as an
   # alternative. The db_blklst_str is shown in the auto-generated release notes
   # instead of the regexp. We can't tell Maria apart from MySQL in our check
-  # and MariaDB skipped versions from 5 to 10, so we'll blacklist 8 and 9 for
+  # and MariaDB skipped versions from 5 to 10, so we'll blocklist 8 and 9 for
   # MariaDB as well just in case someone configured for 'mariadb' but actually
   # has MySQL installed. See https://bugzilla.mozilla.org/show_bug.cgi?id=1851354
   mysql => {db => 'Bugzilla::DB::Mysql', db_version => '5.0.15', name => 'MySQL',
-            db_blacklist => ['^[89]\.'], db_blklst_str => '>= 8.0'},
+            db_blocklist => ['^[89]\.'], db_blklst_str => '>= 8.0'},
   mariadb => {db => 'Bugzilla::DB::Mysql', db_version => '5.1', name => 'MariaDB',
-            db_blacklist => ['^[89]\.']},
+            db_blocklist => ['^[89]\.']},
   pg =>
     {db => 'Bugzilla::DB::Pg', db_version => '9.00.0000', name => 'PostgreSQL'},
   oracle =>

--- a/Bugzilla/DB.pm
+++ b/Bugzilla/DB.pm
@@ -187,12 +187,12 @@ sub bz_check_server_version {
   $self->disconnect;
 
   my $sql_want = $db->{db_version};
-  my $sql_dontwant = exists $db->{db_blacklist} ? $db->{db_blacklist} : [];
+  my $sql_dontwant = exists $db->{db_blocklist} ? $db->{db_blocklist} : [];
   my $version_ok = vers_cmp($sql_vers, $sql_want) > -1 ? 1 : 0;
-  my $blacklisted;
+  my $blocklisted;
   if ($version_ok) {
-    $blacklisted = grep($sql_vers =~ /$_/, @$sql_dontwant);
-    $version_ok = 0 if $blacklisted;
+    $blocklisted = grep($sql_vers =~ /$_/, @$sql_dontwant);
+    $version_ok = 0 if $blocklisted;
   }
 
   my $sql_server = $db->{name};
@@ -202,16 +202,16 @@ sub bz_check_server_version {
       wanted  => $sql_want,
       found   => $sql_vers,
       ok      => $version_ok,
-      blacklisted => $blacklisted
+      blocklisted => $blocklisted
     });
   }
 
   # Check what version of the database server is installed and let
   # the user know if the version is too old to be used with Bugzilla.
-  if ($blacklisted) {
+  if ($blocklisted) {
     die <<EOT;
 
-Your $sql_server v$sql_vers is blacklisted. Please check the
+Your $sql_server v$sql_vers is blocklisted. Please check the
 release notes for details or try a different database engine
 or version.
 

--- a/Bugzilla/Install/Requirements.pm
+++ b/Bugzilla/Install/Requirements.pm
@@ -296,8 +296,8 @@ sub check_font_file {
 
 sub _checking_for {
   my ($params) = @_;
-  my ($package, $ok, $wanted, $blacklisted, $found)
-    = @$params{qw(package ok wanted blacklisted found)};
+  my ($package, $ok, $wanted, $blocklisted, $found)
+    = @$params{qw(package ok wanted blocklisted found)};
 
   my $ok_string = $ok ? install_string('module_ok') : '';
 
@@ -325,10 +325,10 @@ sub _checking_for {
     $ok_string = install_string('module_not_found');
   }
 
-  my $black_string = $blacklisted ? install_string('blacklisted') : '';
+  my $block_string = $blocklisted ? install_string('blocklisted') : '';
   my $want_string = $wanted ? "$wanted" : install_string('any');
 
-  my $str = sprintf "%s %20s %-11s $ok_string $black_string\n",
+  my $str = sprintf "%s %20s %-11s $ok_string $block_string\n",
     (' ' x $checking_for_indent) . install_string('checking_for'), $package,
     "($want_string)";
   print $ok ? $str : colored($str, COLOR_ERROR);

--- a/docs/en/rst/installing/essential-post-install-config.rst
+++ b/docs/en/rst/installing/essential-post-install-config.rst
@@ -90,7 +90,7 @@ This section corresponds to choosing a :param:`mail_delivery_method` of
 :paramval:`Sendmail`.
 
 Unless you know what you are doing, and can deal with the possible problems
-of spam, bounces and blacklists, it is probably unwise to set up your own
+of spam, bounces and blocklists, it is probably unwise to set up your own
 mail server just for Bugzilla. However, if you wish to do so, some guidance
 follows.
 

--- a/t/004template.t
+++ b/t/004template.t
@@ -123,10 +123,10 @@ foreach my $include_path (@include_paths) {
 
     # Forbid single quotes to delimit URLs, see bug 926085.
     if ($data =~ /href=\\?'/) {
-      ok(0, "$path contains blacklisted constructs: href='...'");
+      ok(0, "$path contains blocklisted constructs: href='...'");
     }
     else {
-      ok(1, "$path contains no blacklisted constructs");
+      ok(1, "$path contains no blocklisted constructs");
     }
 
     # Forbid cgi.param(). cgi_param() must be used instead.

--- a/template/en/default/config.js.tmpl
+++ b/template/en/default/config.js.tmpl
@@ -64,7 +64,7 @@ var [% cf.name FILTER js %] = [ [% FOREACH x = cf.legal_values %]'[% x.name FILT
 // =======================
 //
 // It is not necessary to list all products and components here.
-// Instead, you can define a "blacklist" for some commonly used words
+// Instead, you can define a "blocklist" for some commonly used words
 // or word fragments that occur in a product or component name
 // but should _not_ trigger product/component search.
 
@@ -84,7 +84,7 @@ var target_milestone = new Object();
 // Product and Component Exceptions
 // ================================
 //
-// A blacklist for some commonly used words or word fragments 
+// A blocklist for some commonly used words or word fragments
 // that occur in a product or component name but should *not*
 // trigger product/component search in QuickSearch.
 

--- a/template/en/default/setup/strings.txt.pl
+++ b/template/en/default/setup/strings.txt.pl
@@ -32,7 +32,7 @@ END
 The file ##file## must point to a TrueType or OpenType font file
 (its extension must be .ttf or .otf).
 END
-  blacklisted                 => '(blacklisted)',
+  blocklisted                 => '(blocklisted)',
   bz_schema_exists_before_220 => <<'END',
 You are upgrading from a version before 2.20, but the bz_schema table
 already exists. This means that you restored a mysqldump into the Bugzilla


### PR DESCRIPTION
See [Bug 1851354](https://bugzilla.mozilla.org/show_bug.cgi?id=1851354)

The patch on the bugzilla bug had not been r+'d yet.
