### PR TITLE
Bug 1786951: Make the update check work on the 5.0.4 branch

### DIFF
--- a/Bugzilla/Update.pm
+++ b/Bugzilla/Update.pm
@@ -56,7 +56,7 @@ sub get_notifications {
 
     # On which branch is the current installation running?
     my @current_version =
-        (BUGZILLA_VERSION =~ m/^(\d+)\.(\d+)(?:(rc|\.)(\d+))?\+?$/);
+        (BUGZILLA_VERSION =~ m/^(\d+)\.(\d+)(?:\.(\d+))?(?:(rc|\.)(\d+))?\+?$/);
 
     my @release;
     if (Bugzilla->params->{'upgrade_notification'} eq 'development_snapshot') {
@@ -73,7 +73,8 @@ sub get_notifications {
     elsif (Bugzilla->params->{'upgrade_notification'} eq 'stable_branch_release') {
         # We want the latest stable version for the current branch.
         # If we are running a development snapshot, we won't match anything.
-        my $branch_version = $current_version[0] . '.' . $current_version[1];
+        # This is the 5.0.4 branch and it won't branch again so just hardcode this.
+        my $branch_version = '5.0.4'
 
         # We do a string comparison instead of a numerical one, because
         # e.g. 2.2 == 2.20, but 2.2 ne 2.20 (and 2.2 is indeed much older).
@@ -97,12 +98,12 @@ sub get_notifications {
     # Only notify the administrator if the latest version available
     # is newer than the current one.
     my @new_version =
-        ($release[0]->{'latest_ver'} =~ m/^(\d+)\.(\d+)(?:(rc|\.)(\d+))?\+?$/);
+        ($release[0]->{'latest_ver'} =~ m/^(\d+)\.(\d+)(?:\.(\d+))?(?:(rc|\.)(\d+))?\+?$/);
 
     # We convert release candidates 'rc' to integers (rc ? 0 : 1) in order
     # to compare versions easily.
-    $current_version[2] = ($current_version[2] && $current_version[2] eq 'rc') ? 0 : 1;
-    $new_version[2] = ($new_version[2] && $new_version[2] eq 'rc') ? 0 : 1;
+    @current_version = map { s/^(?:rc|)$/0/; s/^\.$/1/; $_; } @current_version;
+    @new_version = map { s/^(?:rc|)$/0/; s/^\.$/1/; $_; } @new_version;
 
     my $is_newer = _compare_versions(\@current_version, \@new_version);
     return ($is_newer == 1) ? {'data' => $release[0]} : undef;

--- a/Bugzilla/Update.pm
+++ b/Bugzilla/Update.pm
@@ -74,7 +74,7 @@ sub get_notifications {
         # We want the latest stable version for the current branch.
         # If we are running a development snapshot, we won't match anything.
         # This is the 5.0.4 branch and it won't branch again so just hardcode this.
-        my $branch_version = '5.0.4'
+        my $branch_version = '5.0.4';
 
         # We do a string comparison instead of a numerical one, because
         # e.g. 2.2 == 2.20, but 2.2 ne 2.20 (and 2.2 is indeed much older).


### PR DESCRIPTION
The update check code is hard-coded to assume that branches only have 2 numbers in them (i.e. 5.0, 5.2, etc).  Of course, the 5.0.4 branch has 3, and its versions will be 5.0.4.1, 5.0.4.2, etc.

So the update check has to be updated to handle it.

There's two sets of things that had to change here:
1) How to figure out which branch it's on.
2) How to parse version numbers in general so we can compare it properly with the one fed back to us by the update check.

For 1) I just opted to hardcode '5.0.4' in there. Every other branch still has the dynamic detection code, and the branch will likely never branch again, so it's not worth wasting effort making the dynamic detection work with it.

For 2) I've added an optional additional number between the main number and the rc section in the big regexp, and also changed the rc detection code to work no matter which position the rc indicator ends up in, instead of assuming it'll always be in the third slot.

To test this, I wrote the following perl script:

```perl
#!/usr/bin/perl

my @version_list = (
    '5.0.5',
    '5.0.4.1',
    '6.0rc1',
    '6.0',
    '5.2',
    '6.0.1'
);

foreach my $version (@version_list) {
    print "\n      input = $version\n";
    my @current_version =
        ($version =~ m/^(\d+)\.(\d+)(?:\.(\d+))?(?:(rc|\.)(\d+))?\+?$/);
    print "first parse = " . join(', ',@current_version) . "\n";
    @current_version = map { s/^(?:rc|)$/0/; s/^\.$/1/; $_; } @current_version;
    print "final parse = " . join(', ',@current_version) . "\n";
}
```
and this produced the following output:
```
      input = 5.0.5
first parse = 5, 0, 5, ,
final parse = 5, 0, 5, 0, 0

      input = 5.0.4.1
first parse = 5, 0, 4, ., 1
final parse = 5, 0, 4, 1, 1

      input = 6.0rc1
first parse = 6, 0, , rc, 1
final parse = 6, 0, 0, 0, 1

      input = 6.0
first parse = 6, 0, , ,
final parse = 6, 0, 0, 0, 0

      input = 5.2
first parse = 5, 2, , ,
final parse = 5, 2, 0, 0, 0

      input = 6.0.1
first parse = 6, 0, 1, ,
final parse = 6, 0, 1, 0, 0
```