### PR TITLE
[5.0] Bug 1850481: Tell 5.0 git users to use 5.2

### DIFF
--- a/THIS_BRANCH_IS_DEAD.txt
+++ b/THIS_BRANCH_IS_DEAD.txt
@@ -2,5 +2,12 @@ Due to some errors with the 5.0.5 and 5.0.6 releases, which contained
 intrusive commits that should not have been made on a stable branch,
 this branch has been retired.
 
-If you came from 5.0.4 or earlier, you can continue on the 5.0.4 branch to get releases 5.0.4.1 and later.
-If you came from 5.0.5 or 5.0.6, you can continue on the 5.2 branch and pick up where this branch left off.
+If you came from 5.0.4 or earlier, you can continue on the 5.0.4 branch to get
+releases 5.0.4.1 and later by using the following command:
+   git checkout 5.0.4
+
+If you came from 5.0.5 or 5.0.6 (the fact you're reading this means this is
+probably you), you can continue on the 5.2 branch and pick up where this
+branch left off by using the following command:
+   git checkout 5.2
+

--- a/checksetup.pl
+++ b/checksetup.pl
@@ -26,6 +26,7 @@ use Safe;
 
 use Bugzilla::Constants;
 use Bugzilla::Install::Requirements;
+use Term::ANSIColor qw(colored);
 use Bugzilla::Install::Util qw(install_string get_version_and_os
   init_console success);
 
@@ -222,6 +223,15 @@ if (Bugzilla->params->{'urlbase'} eq '') {
 }
 if (!$silent) {
   success(get_text('install_success'));
+
+  print colored(<<EOF, COLOR_ERROR);
+
+NOTICE: This installation was git pulled from the 5.0 branch, which is no
+longer supported. Please run `git checkout 5.2` to pick up where this branch left
+off. Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1850481 for details.
+
+EOF
+
 }
 
 __END__

--- a/skins/standard/global.css
+++ b/skins/standard/global.css
@@ -787,6 +787,25 @@ tr.shared_search {
     text-align: center;
 }
 
+#dead_branch {
+    border: 2px solid red;
+    padding: 0.5em 1em;
+    margin: 1em;
+    font-weight: bold;
+}
+
+#dead_branch .notice {
+    font-size: 80%;
+    font-weight: normal;
+}
+
+#dead_branch code {
+    background-color: white;
+    font-size: 110%;
+    padding-left: .5em;
+    padding-right: .5em;
+}
+
 #new_release {
     border: 2px solid red;
     padding: 0.5em 1em;

--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -16,6 +16,14 @@
    header_addl_info = "version $constants.BUGZILLA_VERSION"
 %]
 
+[% IF user.in_group("admin") %]
+  <div id="dead_branch">
+    <p>This installation was git pulled from the 5.0 branch, which is no longer
+    supported. Please run <code>git checkout 5.2</code> to pick up where this branch left off.
+    Please see <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1850481">Bug 1850481</a> for details.</p>
+    <p class="notice">Only members of the 'admin' group can see this message.</p>
+  </div>
+[% END %]
 [% IF release %]
   <div id="new_release">
     [% IF release.data %]


### PR DESCRIPTION
Note this is on the 5.0 branch not 5.0.4. Nobody will ever see this unless they git pull from a 5.0.x git checkout.

Adds the following output at the end of checksetup.pl:
<img width="754" alt="Screenshot 2023-09-09 at 4 31 46 AM" src="https://github.com/bugzilla/bugzilla/assets/307334/f5fca0e4-f9e9-4198-9894-c0bc3a995fbc">

Adds the following banner for admin users only on the home page:
<img width="895" alt="Screenshot 2023-09-09 at 4 33 59 AM" src="https://github.com/bugzilla/bugzilla/assets/307334/f5804895-8143-49f3-84d4-861700c6a01b">

Adds more-detailed text to the THIS_BRANCH_IS_DEAD.txt file in the root of the checkout.
