### PR TITLE
Correctly calculate comment preview size

### DIFF
--- a/js/field.js
+++ b/js/field.js
@@ -1028,8 +1028,12 @@ function show_comment_preview(bug_id) {
     if (!comment || !preview) return;
     if (Dom.hasClass('comment_preview_tab', 'active_comment_tab')) return;
 
-    preview.style.width = (comment.clientWidth - 4) + 'px';
-    preview.style.height = comment.offsetHeight + 'px';
+    var preview_style = getComputedStyle(preview);
+    var preview_hpadding = parseInt(preview_style.paddingLeft) + parseInt(preview_style.paddingRight);
+    var preview_vpadding = parseInt(preview_style.paddingTop) + parseInt(preview_style.paddingBottom);
+
+    preview.style.width = comment.clientWidth - preview_hpadding + 'px';
+    preview.style.height = comment.clientHeight - preview_vpadding + 'px';
 
     var comment_tab = document.getElementById('comment_tab');
     Dom.addClass(comment, 'bz_default_hidden');


### PR DESCRIPTION
#### Details
Instead of trying to guess in the JavaScript what the padding difference is, this PR suggests retrieving it using `getComputedStyle()`. The hard-coded assumption of 4px was wrong. Furthermore, it can break even more for custom CSS themes.

#### Additional info
Patch applied in Cendio's bugzilla for ThinLinc here:
https://bugzilla.cendio.com/show_bug.cgi?id=7867

#### Test Plan
1. Open the show_bug view
2. Start writing a new comment
3. Press the preview tab above the comment textarea
4. Observe that (with the patch) the preview box is now the same size as the comment textarea
