### PR TITLE
"buglist.cgi": Implement proper support for the "splitheader" parameter.

### DIFF
--- a/buglist.cgi
+++ b/buglist.cgi
@@ -950,7 +950,10 @@ if (scalar(@bugowners) > 1 && $user->in_group('editbugs')) {
 
 # Whether or not to split the column titles across two rows to make
 # the list more compact.
-$vars->{'splitheader'} = $cgi->cookie('SPLITHEADER') ? 1 : 0;
+	$vars->{'splitheader'} = (
+	$cgi->cookie('SPLITHEADER') ||
+	$params->param('splitheader') ||
+	$params->param('splitheader') eq '' ? 1 : 0 );
 
 if ($user->settings->{'display_quips'}->{'value'} eq 'on') {
   $vars->{'quip'} = GetQuip();


### PR DESCRIPTION
    Somewhat related:
    https://bugzilla.mozilla.org/show_bug.cgi?id=1572075#c3

    Newly added checks should make "splitheader" in request parameter (either evaluates true, or just exists without value) also work.
