### PR TITLE
Bug 1798166 - Fix color contrast to be compliant with WCAG AA 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,3 @@
 /data
 /localconfig
 /index.html
-
-/skins/contrib/Dusk/admin.css
-/skins/contrib/Dusk/bug.css

--- a/skins/contrib/Dusk/admin.css
+++ b/skins/contrib/Dusk/admin.css
@@ -6,10 +6,10 @@
  * defined by the Mozilla Public License, v. 2.0.
  */
 
-tr.bz_bugitem:hover {
-    background-color: #ccccff;
+#menu td.selected_section {
+    color: #008a00;
 }
 
-.bz_sort_order_secondary {
-  color: #555;
+.sortlist_separator {
+  color: #333;
 }

--- a/skins/contrib/Dusk/bug.css
+++ b/skins/contrib/Dusk/bug.css
@@ -6,10 +6,6 @@
  * defined by the Mozilla Public License, v. 2.0.
  */
 
-tr.bz_bugitem:hover {
-    background-color: #ccccff;
-}
-
-.bz_sort_order_secondary {
-  color: #555;
+.bz_short_desc_container {
+  background-color: #e0e0e0;
 }

--- a/skins/contrib/Dusk/global.css
+++ b/skins/contrib/Dusk/global.css
@@ -21,8 +21,8 @@ body {
 }
 
 #header .links, #footer {
-    background-color: #929bb1;
-    color: #ddd;
+    background-color: #667089;
+    color: #fff;
 }
 
 #header {
@@ -51,7 +51,7 @@ body {
 }
 
 a {
-    color: #6070cf;
+    color: #4659c7;
 }
 a:hover {
     color: #8090ef;
@@ -190,7 +190,7 @@ hr {
 }
 
 .tabs td {
-    background: #c8c8c8;
+    background: #e2e2e2;
     border-width: 1px;
 }
 
@@ -234,4 +234,12 @@ hr {
         margin: 0;
         padding: 0;
     }
+}
+
+/**************/
+/* Bug Fields */
+/**************/
+
+th.required:before, span.required_star {
+    color: #cc3333;
 }


### PR DESCRIPTION
#### Details
<!-- Explain what you did -->
This PR fixes color contrast to be compliant with WCAG AA 2.0

#### Additional info
* [bmo#1798166](https://bugzilla.mozilla.org/show_bug.cgi?id=1798166)

#### Test Plan
<!-- How did you verify the fix/feature in steps -->

I ran the devtools accessibility tools on the different pages.
