### PR TITLE
Bug 1853138 - Switch to Email::Address::XS

### DIFF
--- a/Bugzilla/Config/Common.pm
+++ b/Bugzilla/Config/Common.pm
@@ -11,7 +11,7 @@ use 5.14.0;
 use strict;
 use warnings;
 
-use Email::Address;
+use Email::Address::XS;
 use Socket;
 
 use Bugzilla::Util;
@@ -80,7 +80,8 @@ sub check_regexp {
 
 sub check_email {
   my ($value) = @_;
-  if ($value !~ $Email::Address::mailbox) {
+  my ($mbox) = Email::Address::XS->parse($value);
+  if (!$mbox->is_valid) {
     return "must be a valid email address.";
   }
   return "";

--- a/Bugzilla/FlagType.pm
+++ b/Bugzilla/FlagType.pm
@@ -40,7 +40,7 @@ use Bugzilla::Error;
 use Bugzilla::Util;
 use Bugzilla::Group;
 
-use Email::Address;
+use Email::Address::XS;
 use List::MoreUtils qw(uniq);
 
 use base qw(Bugzilla::Object);
@@ -306,12 +306,12 @@ sub _check_cc_list {
     || ThrowUserError('flag_type_cc_list_invalid', {cc_list => $cc_list});
 
   my @addresses = split(/[,\s]+/, $cc_list);
-  my $addr_spec = $Email::Address::addr_spec;
 
   # We do not call check_email_syntax() because these addresses do not
   # require to match 'emailregexp' and do not depend on 'emailsuffix'.
   foreach my $address (@addresses) {
-    ($address !~ /\P{ASCII}/ && $address =~ /^$addr_spec$/)
+    my $email = Email::Address::XS->parse_bare_address($address); 
+    ($address !~ /\P{ASCII}/ && $email->is_valid)
       || ThrowUserError('illegal_email_address', {addr => $address, default => 1});
   }
   return $cc_list;

--- a/Bugzilla/Install/Requirements.pm
+++ b/Bugzilla/Install/Requirements.pm
@@ -121,8 +121,9 @@ sub REQUIRED_MODULES {
     # versions prior to 3.008 are broken, see https://bugzilla.mozilla.org/show_bug.cgi?id=1560873
     {package => 'Template-Toolkit', module => 'Template', version => '3.008'},
 
-    # 1.300011 has a debug mode for SMTP and automatically pass -i to sendmail.
-    {package => 'Email-Sender', module => 'Email::Sender', version => '1.300011',},
+    # versions prior to 2.600 pulled Email::Address, we now use Email::Address::XS
+    {package => 'Email-Sender', module => 'Email::Sender', version => '2.600',},
+
     {
       package => 'Email-MIME',
       module  => 'Email::MIME',

--- a/Bugzilla/Install/Requirements.pm
+++ b/Bugzilla/Install/Requirements.pm
@@ -124,6 +124,13 @@ sub REQUIRED_MODULES {
     # versions prior to 2.600 pulled Email::Address, we now use Email::Address::XS
     {package => 'Email-Sender', module => 'Email::Sender', version => '2.600',},
 
+    # versions prior to 1.05 contain a security risk
+    {
+      package => 'Email-Address-XS',
+      module  => 'Email::Address::XS',
+      version => '1.05',
+    },
+
     {
       package => 'Email-MIME',
       module  => 'Email::MIME',

--- a/Bugzilla/Migrate/Gnats.pm
+++ b/Bugzilla/Migrate/Gnats.pm
@@ -17,7 +17,7 @@ use Bugzilla::Constants;
 use Bugzilla::Install::Util qw(indicate_progress);
 use Bugzilla::Util qw(format_time trim generate_random_password);
 
-use Email::Address;
+use Email::Address::XS;
 use Email::MIME;
 use File::Basename;
 use IO::File;
@@ -396,10 +396,10 @@ sub _get_gnats_field_data {
   if ($originator !~ Bugzilla->params->{emailregexp}) {
 
     # We use the raw header sometimes, because it looks like "From: user"
-    # which Email::Address won't parse but we can still use.
+    # which Email::Address::XS won't parse but we can still use.
     my $address = $email->header('From');
-    my ($parsed) = Email::Address->parse($address);
-    if ($parsed) {
+    my ($parsed) = Email::Address::XS->parse($address);
+    if ($parsed->is_valid) {
       $address = $parsed->address;
     }
     if ($address) {

--- a/email_in.pl
+++ b/email_in.pl
@@ -24,7 +24,7 @@ BEGIN {
 use lib qw(. lib);
 
 use Data::Dumper;
-use Email::Address;
+use Email::Address::XS;
 use Email::Reply qw(reply);
 use Email::MIME;
 use Getopt::Long qw(:config bundling);
@@ -129,7 +129,7 @@ sub parse_mail {
 
   %fields = %{Bugzilla::Bug::map_fields(\%fields)};
 
-  my ($reporter) = Email::Address->parse($input_email->header('From'));
+  my ($reporter) = Email::Address::XS->parse($input_email->header('From'));
   $fields{'reporter'} = $reporter->address;
 
   # The summary line only affects us if we're doing a post_bug.


### PR DESCRIPTION
This patch updates us from using Email::Address to Email::Address::XS to resolve CVE-2015-7686.

#### Details
Regex comparisons have been replaced by parse + is_valid calls as per current documentation.

#### Additional info
* [bmo#1853138](https://bugzilla.mozilla.org/show_bug.cgi?id=1853138)

#### Test Plan
Test plan is a work in progress.. 😕 
