### PR TITLE
use a non-breaking space between the urlbase and the colon

### DIFF
--- a/template/en/default/email/new-user-details.txt.tmpl
+++ b/template/en/default/email/new-user-details.txt.tmpl
@@ -17,7 +17,7 @@ X-Bugzilla-Type: admin
 
 [This e-mail has been automatically generated]
 
-A new [% terms.Bugzilla %] user account has been created at [% urlbase %]:
+A new [% terms.Bugzilla %] user account has been created at [% urlbase %] :
 
 Login: [% new_user.login %]
 [% IF new_user.realname %]


### PR DESCRIPTION
#### Details
In an email notifying somebody of the creation of his Bugzilla account, this adds a non-breaking space between the Bugzilla url and the colon.

#### Additional info
* [bmo#1342509](https://bugzilla.mozilla.org/show_bug.cgi?id=1342509)

#### Test Plan
<!-- How did you verify the fix/feature in steps -->
1. Go to /editusers.cgi?action=add
2. Create a new user, ensuring "Notify User" is selected.
3. Read the received email
