### PR TITLE
Bug 1433029: Ignore Mac Finder droppings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /data
 /localconfig
 /index.html
+.DS_Store


### PR DESCRIPTION
#### Details
.DS_Store files are droppings from the Mac Finder and can be ignored.

#### Additional info
* [bmo#1433029](https://bugzilla.mozilla.org/show_bug.cgi?id=1433029)
