### PR TITLE
[5.0.4] Backout PR #60 - new feature not valid for stable branch

### DIFF
--- a/Bugzilla/Hook.pm
+++ b/Bugzilla/Hook.pm
@@ -1479,21 +1479,6 @@ look at the code for C<create> in L<Bugzilla::Template>.)
 
 =back
 
-=head2 template_after_create
-
-This hook allows you to manipulate the Template object before it is used.
-You can use this to define new vmethods or filters in extensions.
-
-Params:
-
-=over
-
-=item C<template>
-
-This is the L<Bugzilla::Template> object.
-
-=back
-
 =head2 template_before_process
 
 This hook is called any time Bugzilla processes a template file, including

--- a/Bugzilla/Template.pm
+++ b/Bugzilla/Template.pm
@@ -1186,7 +1186,6 @@ sub create {
     Bugzilla::Hook::process('template_before_create', { config => $config });
     my $template = $class->new($config) 
         || die("Template creation failed: " . $class->error());
-    Bugzilla::Hook::process('template_after_create', { template => $template });
 
     # Pass on our current language to any template hooks or inner templates
     # called by this Template object.

--- a/extensions/Example/Extension.pm
+++ b/extensions/Example/Extension.pm
@@ -920,19 +920,6 @@ sub template_before_create {
     $config->{VARIABLES}->{example_global_variable} = sub { return 'value' };
 }
 
-sub template_after_create {
-    my ( $self, $args ) = @_;
-    my $context = $args->{template}->context;
-
-    # define a pluck method on template toolkit lists.
-    $context->define_vmethod(
-        list => pluck => sub {
-            my ( $list, $field ) = @_;
-            return [ map { $_->$field } @$list ];
-        }
-    );
-}
-
 sub template_before_process {
     my ($self, $args) = @_;
     


### PR DESCRIPTION
#### Details
Reverts PR #60 because it adds a new feature which isn't valid on an old stable branch which should get bugfixes only. There has not been a release on this branch since it landed.

PR #60 did not have a valid bug linked to it either.