### PR TITLE
Updating db_server.rst and mysql.rst regarding mariadb

### DIFF
--- a/docs/en/rst/installing/db_server.rst
+++ b/docs/en/rst/installing/db_server.rst
@@ -3,16 +3,13 @@
 Database Server
 ###############
 
-Bugzilla requires a database to store its data. We recommend either MySQL or
-PostgreSQL for production installations. Oracle 10 should work fine, but very
-little or no testing has been done with Oracle 11 and 12. SQLite is easy to
-configure but, due to its limitations, it should only be used for testing
-purposes and very small installations.
+Bugzilla requires a database to store its data. We recommend either MySQL, MariaDB or PostgreSQL for production installations. Oracle 10 should work fine, but very little or no testing has been done with Oracle 11 and 12. SQLite is easy to configure but, due to its limitations, it should only be used for testing purposes and very small installations.
 
 .. toctree::
    :maxdepth: 1
 
    mysql
+   mariadb
    postgresql
    oracle
    sqlite

--- a/docs/en/rst/installing/db_server.rst
+++ b/docs/en/rst/installing/db_server.rst
@@ -3,7 +3,7 @@
 Database Server
 ###############
 
-Bugzilla requires a database to store its data. We recommend either MySQL, MariaDB or PostgreSQL for production installations. Oracle 10 should work fine, but very little or no testing has been done with Oracle 11 and 12. SQLite is easy to configure but, due to its limitations, it should only be used for testing purposes and very small installations.
+Bugzilla requires a database to store its data. We recommend either MariaDB, MySQL or PostgreSQL for production installations. Oracle 10 should work fine, but very little or no testing has been done with Oracle 11 and 12. SQLite is easy to configure but, due to its limitations, it should only be used for testing purposes and very small installations.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/en/rst/installing/db_server.rst
+++ b/docs/en/rst/installing/db_server.rst
@@ -8,8 +8,8 @@ Bugzilla requires a database to store its data. We recommend MariaDB, MySQL or P
 .. toctree::
    :maxdepth: 1
 
-   mysql
    mariadb
+   mysql
    postgresql
    oracle
    sqlite

--- a/docs/en/rst/installing/db_server.rst
+++ b/docs/en/rst/installing/db_server.rst
@@ -3,7 +3,11 @@
 Database Server
 ###############
 
-Bugzilla requires a database to store its data. We recommend MariaDB, MySQL or PostgreSQL for production installations. Oracle 10 should work fine, but very little or no testing has been done with Oracle 11 and 12. SQLite is easy to configure but, due to its limitations, it should only be used for testing purposes and very small installations.
+Bugzilla requires a database to store its data. We recommend MariaDB, MySQL 
+or PostgreSQL for production installations. Oracle 10 should work fine, but 
+very little or no testing has been done with Oracle 11 and 12. SQLite is easy 
+to configure but, due to its limitations, it should only be used for testing 
+purposes and very small installations.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/en/rst/installing/db_server.rst
+++ b/docs/en/rst/installing/db_server.rst
@@ -3,7 +3,7 @@
 Database Server
 ###############
 
-Bugzilla requires a database to store its data. We recommend either MariaDB, MySQL or PostgreSQL for production installations. Oracle 10 should work fine, but very little or no testing has been done with Oracle 11 and 12. SQLite is easy to configure but, due to its limitations, it should only be used for testing purposes and very small installations.
+Bugzilla requires a database to store its data. We recommend MariaDB, MySQL or PostgreSQL for production installations. Oracle 10 should work fine, but very little or no testing has been done with Oracle 11 and 12. SQLite is easy to configure but, due to its limitations, it should only be used for testing purposes and very small installations.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/en/rst/installing/mariadb.rst
+++ b/docs/en/rst/installing/mariadb.rst
@@ -5,9 +5,7 @@ MariaDB
 
 It is strongly advised to use MariaDB which is fully compatible with Bugzilla.
 
-If MySQL is used, be aware that the minimum required version is MySQL 5.0.15.
-
-All commands in this document work regardless of whether MariaDB or MySQL are used.
+The minimum required version is MariaDB 10.0.5.
 
 It's possible to test which version of MariaDB you have installed with:
 
@@ -38,8 +36,7 @@ server is started when the machine boots.
 Create the Database
 ===================
 
-You need to create a database for Bugzilla to use. Run the :file:`mariadb` (or :file:`mysql`)
-command-line client and enter:
+You need to create a database for Bugzilla to use. Run the :file:`mariadb` command-line client and enter:
 
 ::
     CREATE DATABASE IF NOT EXISTS bugs CHARACTER SET = 'utf8';

--- a/docs/en/rst/installing/mariadb.rst
+++ b/docs/en/rst/installing/mariadb.rst
@@ -73,9 +73,11 @@ To change MariaDB's configuration, you need to edit your MariaDB
 configuration file, which is:
 
 * Red Hat/Fedora: :file:`/etc/my.cnf`
-* Debian/Ubuntu: :file:`/etc/mysql/my.cnf`
+* Debian/Ubuntu: :file:`/etc/mysql/my.cnf` 
 * Windows: :file:`C:\\mysql\\bin\\my.ini`
 * Mac OS X: :file:`/etc/my.cnf`
+
+Or :file:`mariadb.cnf` on Unix-like operating systems.
 
 .. _mysql-max-allowed-packet:
 

--- a/docs/en/rst/installing/mariadb.rst
+++ b/docs/en/rst/installing/mariadb.rst
@@ -75,7 +75,7 @@ configuration file, which is:
 * Red Hat/Fedora: :file:`/etc/my.cnf`
 * Debian/Ubuntu: :file:`/etc/mysql/my.cnf`
 * Windows: :file:`C:\\mysql\\bin\\my.ini`
-* Mac OS X: :file:`/etc/my/cnf`
+* Mac OS X: :file:`/etc/my.cnf`
 
 .. _mysql-max-allowed-packet:
 

--- a/docs/en/rst/installing/mariadb.rst
+++ b/docs/en/rst/installing/mariadb.rst
@@ -11,8 +11,8 @@ It's possible to test which version of MariaDB you have installed with:
 
 :command:`mariadb -e 'select version()'`
 
-For MariaDB versions prior to 10.4.6, replace the mariadb command with mysql 
-with the same arguments. 
+For MariaDB versions prior to 10.4.6, replace the :command:`mariadb` command 
+with :command:`mysql` with the same arguments. 
 
 Installing
 ==========

--- a/docs/en/rst/installing/mariadb.rst
+++ b/docs/en/rst/installing/mariadb.rst
@@ -3,8 +3,6 @@
 MariaDB
 #######
 
-It is strongly advised to use MariaDB which is fully compatible with Bugzilla.
-
 The minimum required version is MariaDB 10.0.5.
 
 It's possible to test which version of MariaDB you have installed with:

--- a/docs/en/rst/installing/mariadb.rst
+++ b/docs/en/rst/installing/mariadb.rst
@@ -9,7 +9,9 @@ The minimum required version is MariaDB 10.0.5.
 
 It's possible to test which version of MariaDB you have installed with:
 
-:command:`mariadb -e 'select version()'` (available in MariaDB 10.4.6 and later) or :command:`mysql -V` ()
+:command:`mariadb -e 'select version()'`
+
+For MariaDB versions prior to 10.4.6, replace the mariadb command with mysql with the same arguments. 
 
 Installing
 ==========

--- a/docs/en/rst/installing/mariadb.rst
+++ b/docs/en/rst/installing/mariadb.rst
@@ -11,7 +11,8 @@ It's possible to test which version of MariaDB you have installed with:
 
 :command:`mariadb -e 'select version()'`
 
-For MariaDB versions prior to 10.4.6, replace the mariadb command with mysql with the same arguments. 
+For MariaDB versions prior to 10.4.6, replace the mariadb command with mysql 
+with the same arguments. 
 
 Installing
 ==========
@@ -38,7 +39,8 @@ server is started when the machine boots.
 Create the Database
 ===================
 
-You need to create a database for Bugzilla to use. Run the :file:`mariadb` command-line client and enter:
+You need to create a database for Bugzilla to use. Run the :file:`mariadb` 
+command-line client and enter:
 
 ::
     CREATE DATABASE IF NOT EXISTS bugs CHARACTER SET = 'utf8';

--- a/docs/en/rst/installing/mariadb.rst
+++ b/docs/en/rst/installing/mariadb.rst
@@ -9,7 +9,7 @@ The minimum required version is MariaDB 10.0.5.
 
 It's possible to test which version of MariaDB you have installed with:
 
-:command:`mariadb -e 'select version()'`
+:command:`mariadb -e 'select version()'` (available in MariaDB 10.4.6 and later) or :command:`mysql -V` ()
 
 Installing
 ==========

--- a/docs/en/rst/installing/mariadb.rst
+++ b/docs/en/rst/installing/mariadb.rst
@@ -1,4 +1,4 @@
-.. _mysql:
+.. _mariadb:
 
 MariaDB
 #######
@@ -12,8 +12,6 @@ All commands in this document work regardless of whether MariaDB or MySQL are us
 It's possible to test which version of MariaDB you have installed with:
 
 :command:`mariadb -e 'select version()'`
-or
-:command:`mysql -e 'select version()'`
 
 Installing
 ==========

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -3,9 +3,12 @@
 MySQL
 #####
 
-It is strongly advised to use MariaDB which is fully compatible with Bugzilla.  If MySQL must be used, be aware that the minimum required version is MySQL 5.6.12.
+It is strongly advised to use MariaDB which is fully compatible with Bugzilla.  
+If MySQL must be used, be aware that the minimum required version is 
+MySQL 5.6.12.
 
-All commands in this document work regardless of whether MySQL or MariaDB are used.
+All commands in this document work regardless of whether MySQL or MariaDB are 
+used.
 
 It's possible to test which version of MySQL you have installed with:
 
@@ -22,7 +25,8 @@ Download the MariaDB 32-bit or 64-bit MSI installer from the
 
 MariaDB has a standard Windows installer. It's ok to select a the
 default install options. The rest of this documentation assumes assume you
-have installed MariaDB into :file:`C:\\mysql`. Adjust paths appropriately if not.
+have installed MariaDB into :file:`C:\\mysql`. Adjust paths appropriately if 
+not.
 
 Linux/Mac OS X
 --------------

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -3,12 +3,7 @@
 MySQL
 #####
 
-It is strongly advised to use MariaDB which is fully compatible with Bugzilla.  
-If MySQL must be used, be aware that the minimum required version is 
-MySQL 5.6.12.
-
-All commands in this document work regardless of whether MySQL or MariaDB are 
-used.
+The minimum required version is MySQL 5.6.12.
 
 It's possible to test which version of MySQL you have installed with:
 
@@ -20,13 +15,14 @@ Installing
 Windows
 -------
 
-Download the MariaDB 32-bit or 64-bit MSI installer from the
-`MariaDB website <https://mariadb.org/download/?t=mariadb&os=windows>`_ (~66 MB).
+Download the MySQL Installer for Windows from the
+[MySQL website](https://dev.mysql.com/downloads/windows/installer/) 
+(sizes vary based on the installer version).
 
-MariaDB has a standard Windows installer. It's ok to select a the
-default install options. The rest of this documentation assumes assume you
-have installed MariaDB into :file:`C:\\mysql`. Adjust paths appropriately if 
-not.
+MySQL provides a standard Windows installer. It is recommended to select the 
+default installation options unless you have specific requirements. This 
+documentation assumes that you have installed MySQL in `C:\mysql`. Adjust paths 
+appropriately if your installation directory differs.
 
 Linux/Mac OS X
 --------------

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -3,8 +3,7 @@
 MariaDB
 #######
 
-It is strongly advised to use MariaDB which is a drop-in replacement for
-MySQL and is fully compatible with Bugzilla. 
+It is strongly advised to use MariaDB which is fully compatible with Bugzilla.
 
 If MySQL is used, be aware that the minimum required version is MySQL 5.0.15.
 

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -1,0 +1,160 @@
+.. _mysql:
+
+MySQL
+#####
+
+It is strongly advised to use MariaDB which is a drop-in replacement for
+MySQL and is fully compatible with Bugzilla.  If MySQL must be used, be
+aware that the minimum required version is MySQL 5.6.12.
+
+All commands in this document work regardless of whether MySQL or
+MariaDB are used.
+
+It's possible to test which version of MySQL you have installed with:
+
+:command:`mysql -V`
+
+Installing
+==========
+
+Windows
+-------
+
+Download the MariaDB 32-bit or 64-bit MSI installer from the
+`MariaDB website <https://mariadb.org/download/?t=mariadb&os=windows>`_ (~66 MB).
+
+MariaDB has a standard Windows installer. It's ok to select a the
+default install options. The rest of this documentation assumes assume you
+have installed MariaDB into :file:`C:\\mysql`. Adjust paths appropriately if not.
+
+Linux/Mac OS X
+--------------
+
+The package install instructions given previously should have installed MySQL
+on your machine, if it didn't come with it already. Run:
+
+:command:`mysql_secure_installation`
+
+and follow its advice.
+
+If you did install MySQL manually rather than from a package, make sure the
+server is started when the machine boots.
+
+Create the Database
+===================
+
+You need to create a database for Bugzilla to use. Run the :file:`mysql`
+command-line client and enter:
+
+::
+    CREATE DATABASE IF NOT EXISTS bugs CHARACTER SET = 'utf8';
+
+The above command makes sure a database like that doesn't exist already.
+
+.. _mysql-add-user:
+
+Add a User
+==========
+
+You need to add a new MySQL user for Bugzilla to use. Run the :file:`mysql`
+command-line client and enter:
+
+::
+
+    GRANT SELECT, INSERT,
+    UPDATE, DELETE, INDEX, ALTER, CREATE, LOCK TABLES,
+    CREATE TEMPORARY TABLES, DROP, REFERENCES ON bugs.*
+    TO bugs@localhost IDENTIFIED BY '$DB_PASS';
+
+    FLUSH PRIVILEGES;
+
+You need to replace ``$DB_PASS`` with a strong password you have chosen.
+Write that password down somewhere.
+
+The above command permits an account called ``bugs``
+to connect from the local machine, ``localhost``. Modify the command to
+reflect your setup if you will be connecting from another
+machine or as a different user.
+
+Change Configuration
+====================
+
+To change MySQL's configuration, you need to edit your MySQL
+configuration file, which is:
+
+* Red Hat/Fedora: :file:`/etc/my.cnf`
+* Debian/Ubuntu: :file:`/etc/mysql/my.cnf`
+* Windows: :file:`C:\\mysql\\bin\\my.ini`
+* Mac OS X: :file:`/etc/my/cnf`
+
+.. _mysql-max-allowed-packet:
+
+Allow Large Attachments and Many Comments
+-----------------------------------------
+
+By default on some systems, MySQL will only allow you to insert things
+into the database that are smaller than 1MB.
+
+Bugzilla attachments
+may be larger than this. Also, Bugzilla combines all comments
+on a single bug into one field for full-text searching, and the
+combination of all comments on a single bug could in some cases
+be larger than 1MB.
+
+We recommend that you allow at least 16MB packets by
+adding or altering the ``max_allowed_packet`` parameter in your MySQL
+configuration in the ``[mysqld]`` section, so that the number is at least
+16M, like this (note that it's ``M``, not ``MB``):
+
+::
+
+    [mysqld]
+    # Allow packets up to 16M
+    max_allowed_packet=16M
+
+.. _mysql-small-words:
+
+Allow Small Words in Full-Text Indexes
+--------------------------------------
+
+By default, words must be at least four characters in length
+in order to be indexed by MySQL's full-text indexes. This causes
+a lot of Bugzilla-specific words to be missed, including "cc",
+"ftp" and "uri".
+
+MySQL can be configured to index those words by setting the
+``ft_min_word_len`` param to the minimum size of the words to index.
+
+::
+
+    [mysqld]
+    # Allow small words in full-text indexes
+    ft_min_word_len=2
+
+.. _mysql-attach-table-size:
+
+Permit Attachments Table to Grow Beyond 4GB
+===========================================
+
+This is optional configuration for Bugzillas which are expected to become
+very large, and needs to be done after Bugzilla is fully installed.
+
+By default, MySQL will limit the size of a table to 4GB.
+This limit is present even if the underlying filesystem
+has no such limit.  To set a higher limit, run the :file:`mysql`
+command-line client and enter the following, replacing ``$bugs_db``
+with your Bugzilla database name (which is ``bugs`` by default):
+
+.. code-block:: sql
+   :force:
+
+    USE $bugs_db;
+    
+    ALTER TABLE attachments AVG_ROW_LENGTH=1000000, MAX_ROWS=20000;
+
+The above command will change the limit to 20GB. MySQL will have
+to make a temporary copy of your entire table to do this, so ideally
+you should do this when your attachments table is still small.
+
+.. note:: If you have set the setting in Bugzilla which allows large
+   attachments to be stored on disk, the above change does not affect that.

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -1,7 +1,7 @@
 .. _mysql:
 
 MariaDB
-#####
+#######
 
 It is strongly advised to use MariaDB which is a drop-in replacement for
 MySQL and is fully compatible with Bugzilla. 

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -1,17 +1,14 @@
 .. _mysql:
 
-MySQL
+MariaDB
 #####
 
 It is strongly advised to use MariaDB which is a drop-in replacement for
-MySQL and is fully compatible with Bugzilla.  If MySQL must be used, be
-aware that the minimum required version is MySQL 5.0.15 and that MySQL 8
-or higher cannot be used at this time.
+MySQL and is fully compatible with Bugzilla. 
 
-All commands in this document work regardless of whether MySQL or
-MariaDB are used.
+All commands in this document work regardless of whether MariaDB or MySQL are used.
 
-It's possible to test which version of MySQL you have installed with:
+It's possible to test which version of MariaDB you have installed with:
 
 :command:`mysql -V`
 
@@ -31,14 +28,14 @@ have installed MariaDB into :file:`C:\\mysql`. Adjust paths appropriately if not
 Linux/Mac OS X
 --------------
 
-The package install instructions given previously should have installed MySQL
+The package install instructions given previously should have installed MariaDB
 on your machine, if it didn't come with it already. Run:
 
 :command:`mysql_secure_installation`
 
 and follow its advice.
 
-If you did install MySQL manually rather than from a package, make sure the
+If you did install MariaDB manually rather than from a package, make sure the
 server is started when the machine boots.
 
 Create the Database
@@ -57,7 +54,7 @@ The above command makes sure a database like that doesn't exist already.
 Add a User
 ==========
 
-You need to add a new MySQL user for Bugzilla to use. Run the :file:`mysql`
+You need to add a new MariaDB user for Bugzilla to use. Run the :file:`mysql`
 command-line client and enter:
 
 ::
@@ -80,7 +77,7 @@ machine or as a different user.
 Change Configuration
 ====================
 
-To change MySQL's configuration, you need to edit your MySQL
+To change MariaDB's configuration, you need to edit your MariaDB
 configuration file, which is:
 
 * Red Hat/Fedora: :file:`/etc/my.cnf`
@@ -93,7 +90,7 @@ configuration file, which is:
 Allow Large Attachments and Many Comments
 -----------------------------------------
 
-By default on some systems, MySQL will only allow you to insert things
+By default on some systems, MariaDB will only allow you to insert things
 into the database that are smaller than 1MB.
 
 Bugzilla attachments
@@ -103,7 +100,7 @@ combination of all comments on a single bug could in some cases
 be larger than 1MB.
 
 We recommend that you allow at least 16MB packets by
-adding or altering the ``max_allowed_packet`` parameter in your MySQL
+adding or altering the ``max_allowed_packet`` parameter in your MariaDB
 configuration in the ``[mysqld]`` section, so that the number is at least
 16M, like this (note that it's ``M``, not ``MB``):
 
@@ -119,11 +116,11 @@ Allow Small Words in Full-Text Indexes
 --------------------------------------
 
 By default, words must be at least four characters in length
-in order to be indexed by MySQL's full-text indexes. This causes
+in order to be indexed by MariaDB's full-text indexes. This causes
 a lot of Bugzilla-specific words to be missed, including "cc",
 "ftp" and "uri".
 
-MySQL can be configured to index those words by setting the
+MariaDB can be configured to index those words by setting the
 ``ft_min_word_len`` param to the minimum size of the words to index.
 
 ::
@@ -140,7 +137,7 @@ Permit Attachments Table to Grow Beyond 4GB
 This is optional configuration for Bugzillas which are expected to become
 very large, and needs to be done after Bugzilla is fully installed.
 
-By default, MySQL will limit the size of a table to 4GB.
+By default, MariaDB will limit the size of a table to 4GB.
 This limit is present even if the underlying filesystem
 has no such limit.  To set a higher limit, run the :file:`mysql`
 command-line client and enter the following, replacing ``$bugs_db``
@@ -153,7 +150,7 @@ with your Bugzilla database name (which is ``bugs`` by default):
     
     ALTER TABLE attachments AVG_ROW_LENGTH=1000000, MAX_ROWS=20000;
 
-The above command will change the limit to 20GB. MySQL will have
+The above command will change the limit to 20GB. MariaDB will have
 to make a temporary copy of your entire table to do this, so ideally
 you should do this when your attachments table is still small.
 

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -6,6 +6,8 @@ MariaDB
 It is strongly advised to use MariaDB which is a drop-in replacement for
 MySQL and is fully compatible with Bugzilla. 
 
+If MySQL is used, be aware that the minimum required version is MySQL 5.0.15.
+
 All commands in this document work regardless of whether MariaDB or MySQL are used.
 
 It's possible to test which version of MariaDB you have installed with:

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -11,7 +11,9 @@ All commands in this document work regardless of whether MariaDB or MySQL are us
 
 It's possible to test which version of MariaDB you have installed with:
 
-:command:`mysql -V`
+:command:`mariadb -e 'select version()'`
+or
+:command:`mysql -e 'select version()'`
 
 Installing
 ==========

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -3,12 +3,9 @@
 MySQL
 #####
 
-It is strongly advised to use MariaDB which is a drop-in replacement for
-MySQL and is fully compatible with Bugzilla.  If MySQL must be used, be
-aware that the minimum required version is MySQL 5.6.12.
+It is strongly advised to use MariaDB which is fully compatible with Bugzilla.  If MySQL must be used, be aware that the minimum required version is MySQL 5.6.12.
 
-All commands in this document work regardless of whether MySQL or
-MariaDB are used.
+All commands in this document work regardless of whether MySQL or MariaDB are used.
 
 It's possible to test which version of MySQL you have installed with:
 

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -32,11 +32,7 @@ Linux/Mac OS X
 --------------
 
 The package install instructions given previously should have installed MariaDB
-on your machine, if it didn't come with it already. Run:
-
-:command:`mysql_secure_installation`
-
-and follow its advice.
+on your machine, if it didn't come with it already. 
 
 If you did install MariaDB manually rather than from a package, make sure the
 server is started when the machine boots.

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -127,29 +127,3 @@ MariaDB can be configured to index those words by setting the
     ft_min_word_len=2
 
 .. _mysql-attach-table-size:
-
-Permit Attachments Table to Grow Beyond 4GB
-===========================================
-
-This is optional configuration for Bugzillas which are expected to become
-very large, and needs to be done after Bugzilla is fully installed.
-
-By default, MariaDB will limit the size of a table to 4GB.
-This limit is present even if the underlying filesystem
-has no such limit.  To set a higher limit, run the :file:`mysql`
-command-line client and enter the following, replacing ``$bugs_db``
-with your Bugzilla database name (which is ``bugs`` by default):
-
-.. code-block:: sql
-   :force:
-
-    USE $bugs_db;
-    
-    ALTER TABLE attachments AVG_ROW_LENGTH=1000000, MAX_ROWS=20000;
-
-The above command will change the limit to 20GB. MariaDB will have
-to make a temporary copy of your entire table to do this, so ideally
-you should do this when your attachments table is still small.
-
-.. note:: If you have set the setting in Bugzilla which allows large
-   attachments to be stored on disk, the above change does not affect that.

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -40,7 +40,7 @@ server is started when the machine boots.
 Create the Database
 ===================
 
-You need to create a database for Bugzilla to use. Run the :file:`mysql`
+You need to create a database for Bugzilla to use. Run the :file:`mariadb` (or :file:`mysql`)
 command-line client and enter:
 
 ::
@@ -53,7 +53,7 @@ The above command makes sure a database like that doesn't exist already.
 Add a User
 ==========
 
-You need to add a new MariaDB user for Bugzilla to use. Run the :file:`mysql`
+You need to add a new MariaDB user for Bugzilla to use. Run the :file:`mariadb`
 command-line client and enter:
 
 ::

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -63,8 +63,6 @@ command-line client and enter:
     CREATE TEMPORARY TABLES, DROP, REFERENCES ON bugs.*
     TO bugs@localhost IDENTIFIED BY '$DB_PASS';
 
-    FLUSH PRIVILEGES;
-
 You need to replace ``$DB_PASS`` with a strong password you have chosen.
 Write that password down somewhere.
 

--- a/docs/en/rst/installing/mysql.rst
+++ b/docs/en/rst/installing/mysql.rst
@@ -82,7 +82,7 @@ configuration file, which is:
 * Red Hat/Fedora: :file:`/etc/my.cnf`
 * Debian/Ubuntu: :file:`/etc/mysql/my.cnf`
 * Windows: :file:`C:\\mysql\\bin\\my.ini`
-* Mac OS X: :file:`/etc/my/cnf`
+* Mac OS X: :file:`/etc/my.cnf`
 
 .. _mysql-max-allowed-packet:
 


### PR DESCRIPTION
#### Details
Updating db_server.rst and mysql.rst to more current information on mariadb

### db_server.rst
1. putting MariaDB first as it is the recommended database

### mysql.rst
2. Changed MySQL to MariaDB in title and running text, since Bugzilla is compatible with MariaDB
3. Changed text about being "MariaDB being drop in compatible with MySQL" to "fully compatible with Bugzilla."
4. Removed comment about MySQL 8.0 not being supported
5. Updated command for version testing to include both mariadb and mysql
6. Updated command line from mysql to mariadb (mentioning mysql first time) 
7. Removed "FLUSH PRIVILEGES;" - never needed with user modification SQL.
8. Removed comment about mysql_secure_installation, since not actively fixed in a while
9. Removed "Permit Attachments Table to Grow Beyond 4GB" as these settings are not applicablity to innodb