### PR TITLE
Bug 1896247: Fix breakage from 5.1 upgrade check

### DIFF
--- a/checksetup.pl
+++ b/checksetup.pl
@@ -121,7 +121,8 @@ my $dbh = Bugzilla->dbh;
 
 # We want to catch if the user is trying to "upgrade" from 5.1 because
 # that's actually a downgrade and you can't do that.
-my $bz51install = $dbh->bz_index_info('bz_schema', 'bz_schema_version_idx');
+my $bz51install;
+eval { $bz51install = $dbh->bz_index_info('bz_schema', 'bz_schema_version_idx'); };
 if ($bz51install) {
   require Bugzilla::Error;
   import Bugzilla::Error;


### PR DESCRIPTION
#### Additional info
* [bmo#1896247](https://bugzilla.mozilla.org/show_bug.cgi?id=1896247)
