### PR TITLE
[4.4] Bug 1851352: Email::Address dependency missing

### DIFF
--- a/Bugzilla/Install/Requirements.pm
+++ b/Bugzilla/Install/Requirements.pm
@@ -144,6 +144,11 @@ sub REQUIRED_MODULES {
         blacklist => ['^2\.196$']
     },
     {
+        package => 'Email-Address',
+        module  => 'Email::Address',
+        version => 0,
+    },
+    {
         package => 'Email-MIME',
         module  => 'Email::MIME',
         # This fixes a memory leak in walk_parts that affected jobqueue.pl.


### PR DESCRIPTION
#### Additional info
* [bmo#1851352](https://bugzilla.mozilla.org/show_bug.cgi?id=1851352)
