### PR TITLE
[5.0.4] Bug 1851352: Email::Address dependency missing

### DIFF
--- a/Bugzilla/Install/Requirements.pm
+++ b/Bugzilla/Install/Requirements.pm
@@ -141,6 +141,11 @@ sub REQUIRED_MODULES {
         version => '1.904'
     },
     {
+        package => 'Email-Address',
+        module  => 'Email::Address',
+        version => 0,
+    },
+    {
         package => 'URI',
         module  => 'URI',
         # Follows RFC 3986 to escape characters in URI::Escape.


### PR DESCRIPTION
#### Additional info
* [bmo#1851352](https://bugzilla.mozilla.org/show_bug.cgi?id=1851352)
