### PR TITLE
[5.3] Bug 1851352: Missing Email::Address dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -62,6 +62,7 @@ my %requires = (
     'Digest::SHA'         => 0,
     'Email::MIME'         => '1.904',
     'Email::Sender'       => '1.300011',
+    'Email::Address'      => 0,
     'HTTP::Request'       => 0,
     'HTTP::Response'      => 0,
     'JSON::XS'            => '2.01',


### PR DESCRIPTION
#### Additional info
* [bmo#1851352](https://bugzilla.mozilla.org/show_bug.cgi?id=1851352)
