### PR TITLE
[5.3] Bug 1634711: backport Bug 1526703 from 5.2 - Increase the size of the flagtype id column

### DIFF
--- a/Bugzilla/DB/Schema.pm
+++ b/Bugzilla/DB/Schema.pm
@@ -630,7 +630,7 @@ use constant ABSTRACT_SCHEMA => {
     FIELDS => [
       id      => {TYPE => 'MEDIUMSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
       type_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         REFERENCES => {TABLE => 'flagtypes', COLUMN => 'id', DELETE => 'CASCADE'}
       },
@@ -666,7 +666,7 @@ use constant ABSTRACT_SCHEMA => {
   # "flagtypes" defines the types of flags that can be set.
   flagtypes => {
     FIELDS => [
-      id               => {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
+      id               => {TYPE => 'MEDIUMSERIAL', NOTNULL => 1, PRIMARYKEY => 1},
       name             => {TYPE => 'varchar(50)', NOTNULL => 1},
       description      => {TYPE => 'MEDIUMTEXT',  NOTNULL => 1},
       cc_list          => {TYPE => 'varchar(200)'},
@@ -693,7 +693,7 @@ use constant ABSTRACT_SCHEMA => {
   flaginclusions => {
     FIELDS => [
       type_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         REFERENCES => {TABLE => 'flagtypes', COLUMN => 'id', DELETE => 'CASCADE'}
       },
@@ -715,7 +715,7 @@ use constant ABSTRACT_SCHEMA => {
   flagexclusions => {
     FIELDS => [
       type_id => {
-        TYPE       => 'INT2',
+        TYPE       => 'INT3',
         NOTNULL    => 1,
         REFERENCES => {TABLE => 'flagtypes', COLUMN => 'id', DELETE => 'CASCADE'}
       },

--- a/Bugzilla/Install/DB.pm
+++ b/Bugzilla/Install/DB.pm
@@ -475,9 +475,8 @@ sub update_table_definitions {
   $dbh->bz_drop_column('profiles', 'refreshed_when');
   $dbh->bz_drop_column('groups',   'last_changed');
 
-  # 2006-08-06 LpSolit@gmail.com - Bug 347521
-  $dbh->bz_alter_column('flagtypes', 'id',
-    {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1});
+  # 2019-01-31 dylan@hardison.net - Bug TODO
+  _update_flagtypes_id();
 
   $dbh->bz_alter_column('keyworddefs', 'id',
     {TYPE => 'SMALLSERIAL', NOTNULL => 1, PRIMARYKEY => 1});
@@ -836,6 +835,30 @@ sub _update_product_name_definition {
     $dbh->bz_alter_column('products',   'product', {TYPE => 'varchar(64)'});
     $dbh->bz_alter_column('versions', 'program',
       {TYPE => 'varchar(64)', NOTNULL => 1});
+  }
+}
+
+sub _update_flagtypes_id {
+  my $dbh   = Bugzilla->dbh;
+  my @fixes = (
+    {table => 'flaginclusions', column => 'type_id'},
+    {table => 'flagexclusions', column => 'type_id'},
+    {table => 'flags',          column => 'type_id'},
+  );
+  my $flagtypes_def = $dbh->bz_column_info('flagtypes', 'id');
+  foreach my $fix (@fixes) {
+    my $def = $dbh->bz_column_info($fix->{table}, $fix->{column});
+    if ($def->{TYPE} eq 'INT2') {
+      warn "Dropping $fix->{table}\n";
+      $dbh->bz_drop_related_fks($fix->{table}, $fix->{column});
+      $def->{TYPE} = 'INT3';
+      $dbh->bz_alter_column($fix->{table}, $fix->{column}, $def);
+    }
+  }
+
+  if ($flagtypes_def->{TYPE} eq 'SMALLSERIAL') {
+    $flagtypes_def->{TYPE} = 'MEDIUMSERIAL';
+    $dbh->bz_alter_column('flagtypes', 'id', $flagtypes_def);
   }
 }
 


### PR DESCRIPTION
#### Details
cherry-picked the Bug 1526703 patch from the 5.0.6 release, which was missing from 5.1/5.3

#### Additional info
* [bmo#1634711](https://bugzilla.mozilla.org/show_bug.cgi?id=1634711)
