### PR TITLE
Bug 1848099: Signup form email field needs a label

### DIFF
--- a/template/en/default/account/create.html.tmpl
+++ b/template/en/default/account/create.html.tmpl
@@ -64,13 +64,13 @@
 [% END %]
 
 <form id="account_creation_form" method="get" action="createaccount.cgi">
-  <span class="label">
+  <label for="login"><span class="label">
     [% IF Param('emailsuffix') %]
       Login:
     [% ELSE %]
       Email address:
     [% END %]
-  </span>
+  </span></label>
   <input size="35" id="login" name="login" autofocus
          [%- ' type="email"' UNLESS Param('emailsuffix') %] required>
   [% Param('emailsuffix') FILTER html %]

--- a/template/en/default/global/common-links.html.tmpl
+++ b/template/en/default/global/common-links.html.tmpl
@@ -29,7 +29,7 @@
       }
     </script>
     <input class="txt" type="text" id="quicksearch[% qs_suffix FILTER html %]"
-           name="quicksearch" aria-label="Quick Search"
+           name="quicksearch" aria-labelledby="find[% qs_suffix FILTER html %]"
            title="Quick Search" value="[% quicksearch FILTER html %]">
     <input class="btn" type="submit" value="Search" 
            id="find[% qs_suffix FILTER html %]">

--- a/template/en/default/global/common-links.html.tmpl
+++ b/template/en/default/global/common-links.html.tmpl
@@ -28,7 +28,8 @@
         no_redirect.value = 1;
       }
     </script>
-    <input class="txt" type="text" id="quicksearch[% qs_suffix FILTER html %]" name="quicksearch" 
+    <input class="txt" type="text" id="quicksearch[% qs_suffix FILTER html %]"
+           name="quicksearch" aria-label="Quick Search"
            title="Quick Search" value="[% quicksearch FILTER html %]">
     <input class="btn" type="submit" value="Search" 
            id="find[% qs_suffix FILTER html %]">

--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -138,10 +138,12 @@
         <a href="buglist.cgi?chfield=%5BBug%20creation%5D&amp;chfieldfrom=24h">last 24 hours</a>
         [% title = BLOCK %][% terms.Bugs %] reported in the last 24 hours[% END %]
         <a href="buglist.cgi?chfield=%5BBug%20creation%5D&amp;chfieldfrom=24h&amp;ctype=atom&amp;title=[% title FILTER uri %]"
+           aria-label="Bugs reported in the last 24 hours - RSS feed"
            class="rss">&nbsp;</a>
         | <a href="buglist.cgi?chfield=%5BBug%20creation%5D&amp;chfieldfrom=7d">last 7 days</a>
         [% title = BLOCK %][% terms.Bugs %] reported in the last 7 days[% END %]
         <a href="buglist.cgi?chfield=%5BBug%20creation%5D&amp;chfieldfrom=7d&amp;ctype=atom&amp;title=[% title FILTER uri %]"
+           aria-label="Bugs reported in the last 7 days - RSS feed"
            class="rss">&nbsp;</a>
       </li>
       <li>
@@ -149,10 +151,12 @@
         <a href="buglist.cgi?chfieldfrom=24h">last 24 hours</a>
         [% title = BLOCK %][% terms.Bugs %] changed in the last 24 hours[% END %]
         <a href="buglist.cgi?chfieldfrom=24h&amp;ctype=atom&amp;title=[% title FILTER uri %]"
+           aria-label="Bugs changed in the last 24 hours - RSS feed"
            class="rss">&nbsp;</a>
         | <a href="buglist.cgi?chfieldfrom=7d">last 7 days</a>
         [% title = BLOCK %][% terms.Bugs %] changed in the last 7 days[% END %]
         <a href="buglist.cgi?chfieldfrom=7d&amp;ctype=atom&amp;title=[% title FILTER uri %]"
+           aria-label="Bugs changed in the last 7 days - RSS feed"
            class="rss">&nbsp;</a>
       </li>
     </ul>

--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -93,7 +93,7 @@
     <form id="quicksearchForm" name="quicksearchForm" action="buglist.cgi">
       <input id="quicksearch_main" name="quicksearch" title="Quick Search"
              placeholder="Enter [% terms.abug %] # or some search terms"
-             aria-label="Quick Search"
+             aria-labelledby="find"
              autofocus required>
       <input id="find" type="submit" value="Quick Search">
       <a href="page.cgi?id=quicksearch.html" title="Quick Search help">[?]</a>

--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -93,6 +93,7 @@
     <form id="quicksearchForm" name="quicksearchForm" action="buglist.cgi">
       <input id="quicksearch_main" name="quicksearch" title="Quick Search"
              placeholder="Enter [% terms.abug %] # or some search terms"
+             aria-label="Quick Search"
              autofocus required>
       <input id="find" type="submit" value="Quick Search">
       <a href="page.cgi?id=quicksearch.html" title="Quick Search help">[?]</a>

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -17,7 +17,8 @@
   to search for:</label></p>
 
 <form name="f" action="buglist.cgi" method="get">
-  <input size="40" name="quicksearch" id="quicksearch" autofocus required>
+  <input size="40" name="quicksearch" id="quicksearch"
+         aria-label="Quick Search" autofocus required>
   <input type="submit" value="Search" id="find">
 </form>
 

--- a/template/en/default/pages/quicksearch.html.tmpl
+++ b/template/en/default/pages/quicksearch.html.tmpl
@@ -18,7 +18,7 @@
 
 <form name="f" action="buglist.cgi" method="get">
   <input size="40" name="quicksearch" id="quicksearch"
-         aria-label="Quick Search" autofocus required>
+         aria-labelledby="find" autofocus required>
   <input type="submit" value="Search" id="find">
 </form>
 


### PR DESCRIPTION
#### Details
Add label tag to existing label on the email address/login name field

#### Additional info
* [bug#1848099](https://bugzilla.mozilla.org/show_bug.cgi?id=1848099)

Note: this depends on #177, it needs to land first.