### PR TITLE
WebService/Product: provide default CC list of a Component

### DIFF
--- a/Bugzilla/WebService/Product.pm
+++ b/Bugzilla/WebService/Product.pm
@@ -268,6 +268,7 @@ sub _component_to_hash {
     sort_key =>    # sort_key is returned to match Bug.fields
       0,
     is_active => $self->type('boolean', $component->is_active),
+    default_cc => [map $self->type('string', $_->login), @{$component->initial_cc}],
     },
     undef, 'components';
 


### PR DESCRIPTION
The default_cc list of a component should be provided when getting its info from product.

#### Details
This PR fixes/adds default_cc to the Component object when returning it within API (/rest/product?ids=12345 e.g.)

#### Additional info
* [bug#1172249](https://bugzilla.mozilla.org/show_bug.cgi?id=1172249)
