### PR TITLE
[4.4] Bug 1852154: Warn admin if end-of-support date is approaching

### DIFF
--- a/Bugzilla/Update.pm
+++ b/Bugzilla/Update.pm
@@ -48,7 +48,7 @@ sub get_notifications {
             'status'     => $branch->{'att'}->{'status'},
             'url'        => $branch->{'att'}->{'url'},
             'date'       => $branch->{'att'}->{'date'},
-	    'eos_date'   => exists($branch->{'att'}->{'eos-date'}) ? $branch->{'att'}->{'eos-date'} : undef,
+            'eos_date'   => exists($branch->{'att'}->{'eos-date'}) ? $branch->{'att'}->{'eos-date'} : undef,
         };
         push(@releases, $release);
     }
@@ -94,8 +94,8 @@ sub get_notifications {
             return {'data' => $release[0], 'deprecated' => $branch_version};
         }
 
-	# If we get here, then we want to recommend the lastest stable
-	# release without any other messages.
+        # If we get here, then we want to recommend the lastest stable
+        # release without any other messages.
         @release = grep {$_->{'status'} eq 'stable'} @releases;
     }
     elsif (Bugzilla->params->{'upgrade_notification'} eq 'stable_branch_release') {
@@ -110,14 +110,14 @@ sub get_notifications {
         # If the branch has an end-of-support date listed, we should
         # strongly suggest to upgrade to the latest stable release
         # available.
-	if (scalar(@release) && $release[0]->{'status'} ne 'closed'
-	    && defined($release[0]->{'eos_date'})) {
+       if (scalar(@release) && $release[0]->{'status'} ne 'closed'
+            && defined($release[0]->{'eos_date'})) {
             my $eos_date = $release[0]->{'eos_date'};
             @release = grep {$_->{'status'} eq 'stable'} @releases;
             return {'data' => $release[0],
                     'branch_version' => $branch_version,
-                    'eos_date' => $eos_date};
-	};
+                    'eos_date' => $eos_date}
+        };
 
         # If the branch is now closed, we should strongly suggest
         # to upgrade to the latest stable release available.

--- a/Bugzilla/Update.pm
+++ b/Bugzilla/Update.pm
@@ -67,6 +67,35 @@ sub get_notifications {
         }
     }
     elsif (Bugzilla->params->{'upgrade_notification'} eq 'latest_stable_release') {
+        # We want the latest stable version for the current branch.
+        # If we are running a development snapshot, we won't match anything.
+        my $branch_version = $current_version[0] . '.' . $current_version[1];
+
+        # We do a string comparison instead of a numerical one, because
+        # e.g. 2.2 == 2.20, but 2.2 ne 2.20 (and 2.2 is indeed much older).
+        @release = grep {$_->{'branch_ver'} eq $branch_version} @releases;
+
+        # If the branch has an end-of-support date listed, we should
+        # strongly suggest to upgrade to the latest stable release
+        # available.
+        if (scalar(@release) && $release[0]->{'status'} ne 'closed'
+            && defined($release[0]->{'eos_date'})) {
+            my $eos_date = $release[0]->{'eos_date'};
+            @release = grep {$_->{'status'} eq 'stable'} @releases;
+            return {'data' => $release[0],
+                    'branch_version' => $branch_version,
+                    'eos_date' => $eos_date};
+        };
+
+        # If the branch is now closed, we should strongly suggest
+        # to upgrade to the latest stable release available.
+        if (scalar(@release) && $release[0]->{'status'} eq 'closed') {
+            @release = grep {$_->{'status'} eq 'stable'} @releases;
+            return {'data' => $release[0], 'deprecated' => $branch_version};
+        }
+
+	# If we get here, then we want to recommend the lastest stable
+	# release without any other messages.
         @release = grep {$_->{'status'} eq 'stable'} @releases;
     }
     elsif (Bugzilla->params->{'upgrade_notification'} eq 'stable_branch_release') {

--- a/Bugzilla/Update.pm
+++ b/Bugzilla/Update.pm
@@ -47,7 +47,8 @@ sub get_notifications {
             'latest_ver' => $branch->{'att'}->{'vid'},
             'status'     => $branch->{'att'}->{'status'},
             'url'        => $branch->{'att'}->{'url'},
-            'date'       => $branch->{'att'}->{'date'}
+            'date'       => $branch->{'att'}->{'date'},
+	    'eos_date'   => exists($branch->{'att'}->{'eos-date'}) ? $branch->{'att'}->{'eos-date'} : undef,
         };
         push(@releases, $release);
     }
@@ -76,6 +77,18 @@ sub get_notifications {
         # We do a string comparison instead of a numerical one, because
         # e.g. 2.2 == 2.20, but 2.2 ne 2.20 (and 2.2 is indeed much older).
         @release = grep {$_->{'branch_ver'} eq $branch_version} @releases;
+
+        # If the branch has an end-of-support date listed, we should
+        # strongly suggest to upgrade to the latest stable release
+        # available.
+	if (scalar(@release) && $release[0]->{'status'} ne 'closed'
+	    && defined($release[0]->{'eos_date'})) {
+            my $eos_date = $release[0]->{'eos_date'};
+            @release = grep {$_->{'status'} eq 'stable'} @releases;
+            return {'data' => $release[0],
+                    'branch_version' => $branch_version,
+                    'eos_date' => $eos_date};
+	};
 
         # If the branch is now closed, we should strongly suggest
         # to upgrade to the latest stable release available.

--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -58,6 +58,12 @@ YAHOO.util.Event.onDOMReady(onLoadActions);
 [% IF release %]
   <div id="new_release">
     [% IF release.data %]
+      [% IF release.eos_date %]
+        <p>[% terms.Bugzilla %] [%+ release.branch_version FILTER html %] will
+        no longer receive security updates after [% release.eos_date FILTER html %].
+        You are highly encouraged to upgrade in order to keep your
+        system secure.</p>
+      [% END %]
       [% IF release.deprecated %]
         <p>[% terms.Bugzilla %] [%+ release.deprecated FILTER html %] is no longer
         supported. You are highly encouraged to upgrade in order to keep your


### PR DESCRIPTION
#### Additional info
* [bug#1852154](https://bugzilla.mozilla.org/show_bug.cgi?id=1852154)

#### Test Plan
<!-- How did you verify the fix/feature in steps -->
1. modify data/bugzilla-update.xml locally to add an eos-date="2024-09-20" to the 4.4 branch (example date, subject to change)
2. load the front page of Bugzilla while logged in as an administrator.
3. The message that security support will be ending on that date should appear.
4. Test with both stable_branch_release and latest_stable_release