### PR TITLE
[5.0.4] Bug 1852154: Warn admin if end-of-support date is approaching

### DIFF
--- a/Bugzilla/Update.pm
+++ b/Bugzilla/Update.pm
@@ -97,8 +97,8 @@ sub get_notifications {
             return {'data' => $release[0], 'deprecated' => $branch_version};
         }
 
-	# If we get here, then we want to recommend the lastest stable
-	# release without any other messages.
+        # If we get here, then we want to recommend the lastest stable
+        # release without any other messages.
         @release = grep {$_->{'status'} eq 'stable'} @releases;
     }
     elsif (Bugzilla->params->{'upgrade_notification'} eq 'stable_branch_release') {

--- a/template/en/default/index.html.tmpl
+++ b/template/en/default/index.html.tmpl
@@ -19,6 +19,12 @@
 [% IF release %]
   <div id="new_release">
     [% IF release.data %]
+      [% IF release.eos_date %]
+        <p>[% terms.Bugzilla %] [%+ release.branch_version FILTER html %] will
+        no longer receive security updates after [% release.eos_date FILTER html %].
+        You are highly encouraged to upgrade in order to keep your
+        system secure.</p>
+      [% END %]
       [% IF release.deprecated %]
         <p>Bugzilla [%+ release.deprecated FILTER html %] is no longer
         supported. You are highly encouraged to upgrade in order to keep your


### PR DESCRIPTION
#### Additional info
* [bug#1852154](https://bugzilla.mozilla.org/show_bug.cgi?id=1852154)

#### Test Plan
<!-- How did you verify the fix/feature in steps -->
1. modify data/bugzilla-update.xml locally to add an eos-date="2024-09-20" to the 5.0.4 branch (have to create the branch in the file, example date, subject to change)
2. load the front page of Bugzilla while logged in as an administrator.
3. The message that security support will be ending on that date should appear.
4. Test with both stable_branch_release and latest_stable_release