### PR TITLE
[5.2] Bug 1915225: Allow custom scripts within docker container

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+SCRIPTS_DIR="/custom-scripts"
+
+# Execute any custom scripts prior to starting services
+if [[ -e "${SCRIPTS_DIR}" ]] && [[ -n "$(/bin/ls -A ${SCRIPTS_DIR} 2>/dev/null)" ]]; then
+    echo "[custom-scripts] Files found, executing"
+    for SCRIPT in "${SCRIPTS_DIR}"/*; do
+        NAME="$(basename "${SCRIPT}")"
+        if [[ -f "${SCRIPT}" ]]; then
+            echo "[custom-scripts] ${NAME}: executing..."
+            /bin/bash "${SCRIPT}"
+            echo "[custom-scripts] ${NAME}: exited $?"
+        elif [[ ! -f "${SCRIPT}" ]]; then
+            echo "[custom-scripts] ${NAME}: is not a file"
+        fi
+    done
+else
+    echo "[custom-scripts] No custom scripts found, continuing with startup..."
+fi
+
 [ -z "$BZ_DB_HOST" ] && echo "Missing Docker Environment, check docker-compose.yml" && exit -1
 cd /var/www/html
 apachectl start


### PR DESCRIPTION
Details:
This PR fixes/adds the ability to run custom scripts within the docker container at startup. This is useful if you need to extend the functionality of the container in some way without having to fork from the stock Dockerfile/image provided by the project.

For example, I use mod_auth_openidc for Apache in order to provide Bugzilla with the ability to authenticate users via Okta/OIDC. A custom scripts function would allow me to setup a script to install the apache2 module and provide the configuration without having to modify the Dockerfile or create a new container image with the changes.

Another example would be to provide custom configuration changes to the base container, e.g. using something like sed to adjust/modify the set_max_unshared_size parameters in mod_perl.pl.

Additional Info:
* [bug#1915225](https://bugzilla.mozilla.org/show_bug.cgi?id=1915225)

Test Plan:
1. Modified the startup.sh script to include logic for handling custom scripts
2. Mounted a volume at /custom-scripts that contains custom scripts to run during startup
3. Started container and verified container started properly and custom scripts were run, making the requested changes

```
[root@ip-10-242-4-152 bugzilla]# docker compose up
[+] Running 2/2
 ✔ Network bugzilla                   Created                                                                                                                                                                                                                                          0.1s
 ✔ Container bugzilla-bugzilla-app-1  Created                                                                                                                                                                                                                                          0.1s
Attaching to bugzilla-app-1
bugzilla-app-1  | [custom-scripts] Files found, executing
bugzilla-app-1  | [custom-scripts] mod_openidc.sh: executing...
bugzilla-app-1  | Reading package lists...
bugzilla-app-1  | Building dependency tree...
bugzilla-app-1  | Reading state information...
bugzilla-app-1  | The following additional packages will be installed:
bugzilla-app-1  |   libcjose0 libhiredis1.1.0
bugzilla-app-1  | The following NEW packages will be installed:
bugzilla-app-1  |   libapache2-mod-auth-openidc libcjose0 libhiredis1.1.0
bugzilla-app-1  | 0 upgraded, 3 newly installed, 0 to remove and 0 not upgraded.
bugzilla-app-1  | Need to get 268 kB of archives.
bugzilla-app-1  | After this operation, 1059 kB of additional disk space will be used.
bugzilla-app-1  | Get:1 http://ports.ubuntu.com/ubuntu-ports noble/universe arm64 libhiredis1.1.0 arm64 1.2.0-6ubuntu3 [40.7 kB]
bugzilla-app-1  | Get:2 http://ports.ubuntu.com/ubuntu-ports noble/universe arm64 libcjose0 arm64 0.6.2.2-1build3 [35.4 kB]
bugzilla-app-1  | Get:3 http://ports.ubuntu.com/ubuntu-ports noble/universe arm64 libapache2-mod-auth-openidc arm64 2.4.15.1-1build3 [192 kB]
bugzilla-app-1  | debconf: delaying package configuration, since apt-utils is not installed
bugzilla-app-1  | Fetched 268 kB in 1s (464 kB/s)
bugzilla-app-1  | Selecting previously unselected package libhiredis1.1.0:arm64.
(Reading database ... 28509 files and directories currently installed.)
bugzilla-app-1  | Preparing to unpack .../libhiredis1.1.0_1.2.0-6ubuntu3_arm64.deb ...
bugzilla-app-1  | Unpacking libhiredis1.1.0:arm64 (1.2.0-6ubuntu3) ...
bugzilla-app-1  | Selecting previously unselected package libcjose0:arm64.
bugzilla-app-1  | Preparing to unpack .../libcjose0_0.6.2.2-1build3_arm64.deb ...
bugzilla-app-1  | Unpacking libcjose0:arm64 (0.6.2.2-1build3) ...
bugzilla-app-1  | Selecting previously unselected package libapache2-mod-auth-openidc.
bugzilla-app-1  | Preparing to unpack .../libapache2-mod-auth-openidc_2.4.15.1-1build3_arm64.deb ...
bugzilla-app-1  | Unpacking libapache2-mod-auth-openidc (2.4.15.1-1build3) ...
bugzilla-app-1  | Setting up libhiredis1.1.0:arm64 (1.2.0-6ubuntu3) ...
bugzilla-app-1  | Setting up libcjose0:arm64 (0.6.2.2-1build3) ...
bugzilla-app-1  | Setting up libapache2-mod-auth-openidc (2.4.15.1-1build3) ...
bugzilla-app-1  | apache2_invoke: Enable module auth_openidc
bugzilla-app-1  | invoke-rc.d: could not determine current runlevel
bugzilla-app-1  | invoke-rc.d: policy-rc.d denied execution of restart.
bugzilla-app-1  | apache2_invoke: Enable configuration auth_openidc
bugzilla-app-1  | invoke-rc.d: could not determine current runlevel
bugzilla-app-1  | invoke-rc.d: policy-rc.d denied execution of reload.
bugzilla-app-1  | Processing triggers for libc-bin (2.39-0ubuntu8.3) ...
bugzilla-app-1  | [custom-scripts] mod_openidc.sh: exited 0
bugzilla-app-1  | [custom-scripts] mod_perl_sizelimit.sh: executing...
bugzilla-app-1  | [custom-scripts] mod_perl_sizelimit.sh: exited 0
bugzilla-app-1  | Waiting for database to be available...
bugzilla-app-1  | Checking database...
bugzilla-app-1  | Beginning checksetup...
bugzilla-app-1  | Re-run checksetup.pl in interactive mode (without an 'answers' file)
bugzilla-app-1  | to continue.
bugzilla-app-1  |
bugzilla-app-1  | WARNING: We are about to convert your table storage format to UTF-8. This
bugzilla-app-1  |          allows Bugzilla to correctly store and sort international characters.
bugzilla-app-1  |          However, if you have any non-UTF-8 data in your database,
bugzilla-app-1  |          it ***WILL BE DELETED*** by this process. So, before
bugzilla-app-1  |          you continue with checksetup.pl, if you have any non-UTF-8
bugzilla-app-1  |          data (or even if you're not sure) you should press Ctrl-C now
bugzilla-app-1  |          to interrupt checksetup.pl, and run contrib/recode.pl to convert
bugzilla-app-1  |          the data in your database into UTF-8. You should also back up your
bugzilla-app-1  |          database before continuing. This will affect every single table
bugzilla-app-1  |          in the database, even non-Bugzilla tables.
bugzilla-app-1  |
bugzilla-app-1  |          If you ever used a version of Bugzilla before 2.22, we STRONGLY
bugzilla-app-1  |          recommend that you stop checksetup.pl NOW and run contrib/recode.pl.
bugzilla-app-1  | Checksetup completed.
bugzilla-app-1  | #########################################
bugzilla-app-1  | ##                                     ##
bugzilla-app-1  | ##  Your Bugzilla installation should  ##
bugzilla-app-1  | ##         now be reachable at:        ##
bugzilla-app-1  | ##                                     ##
bugzilla-app-1  | ## https://bugzilla.<redacted>.dev/ ##
bugzilla-app-1  | ##                                     ##
bugzilla-app-1  | ##Admin user: <redacted>@<redacted>    ##
bugzilla-app-1  | ##Admin password: <redacted> ##
bugzilla-app-1  | ##                                     ##
bugzilla-app-1  | ##   user/password only valid if you   ##
bugzilla-app-1  | ##    haven't already changed them.    ##
bugzilla-app-1  | ##                                     ##
bugzilla-app-1  | #########################################
```
