### PR TITLE
allow preview of comment in new bugs

### DIFF
--- a/js/field.js
+++ b/js/field.js
@@ -1078,7 +1078,7 @@ function show_comment_preview(bug_id) {
         method: 'Bug.render_comment',
         params: {
             Bugzilla_api_token: BUGZILLA.api_token,
-            id: bug_id,
+            id: bug_id ? bug_id : 1,
             text: comment.value
         }
     })


### PR DESCRIPTION
FreeBSD Bug 250699 is titled " Preview tab is blank for new issues" (q.v.)

This suggested workaround seems to fix this problem in practice.

Note: the changed code is only applicable to 5.0.4 and 5.2 -- the file is completely rewritten in harmony.  For this reason, using this as a workaround, rather than finding the underlying bug it obviates, is probably sufficient for existing Bugzill installations.

tbd: evaluate whether this fixes Bugzilla Bug 1247165.

<!--

#### Instructions

1. All pull requests to an officially supported branch must be accompanied by a bug report on bugzilla.mozilla.org. Please stop and file one there if you haven't already, or look for an existing one that fits what you're doing (the bug entry form will automatically search for things that look similar to the Summary you enter).
   File a bug report: https://bugzilla.mozilla.org/enter_bug.cgi?product=Bugzilla
2. GitHub will automatically attach your pull request to the bug report in Bugzilla if you have "Bug #######" in the title of the pull request, where ####### is the bug number. For readability, we recommend putting it at the beginning of the title.
3. If it's not otherwise obvious from the title which branch the pull request applies to, please put the name of the branch in square brackets at the beginning of the title.

 Example title:
   [5.2] Bug 1234: Change Foo to do Bar
-->

#### Details
<!-- Explain what you did -->
This PR fixes/adds a feature...

#### Additional info
<!-- Paste the bug number after the # and after the = in the following line. -->
* [bug#](https://bugzilla.mozilla.org/show_bug.cgi?id=)

#### Test Plan
<!-- How did you verify the fix/feature in steps -->
1. Open the show_bug view
2. Edit the bug
3. ...
