### PR TITLE
[5.2] Bug 2040088: Docs update - file is used before download

### DIFF
--- a/docs/en/rst/installing/quick-start.rst
+++ b/docs/en/rst/installing/quick-start.rst
@@ -68,6 +68,22 @@ the next steps (up to step 7) in another terminal while you wait for the
 second command to finish. If you start another terminal, you will need to
 :command:`sudo su` again.
 
+Download Bugzilla
+=================
+
+Get it from our Git repository:
+
+:command:`mkdir -p /var/www/webapps`
+
+:command:`cd /var/www/webapps`
+
+:command:`git clone --branch release-X.X-stable https://github.com/bugzilla/bugzilla bugzilla`
+
+(where "X.X" is the 2-digit version number of the stable release of Bugzilla
+that you want - e.g. 5.2)
+
+:command:`cd bugzilla`
+
 Configure MariaDB
 =================
 
@@ -115,20 +131,6 @@ For more in depth setup instructions, refer to :ref:`Apache section of this docu
 :command:`a2enmod cgid headers expires rewrite`
 
 :command:`service apache2 restart`
-
-Download Bugzilla
-=================
-
-Get it from our Git repository:
-
-:command:`mkdir -p /var/www/webapps`
-
-:command:`cd /var/www/webapps`
-
-:command:`git clone --branch release-X.X-stable https://github.com/bugzilla/bugzilla bugzilla`
-
-(where "X.X" is the 2-digit version number of the stable release of Bugzilla
-that you want - e.g. 5.2)
 
 Install Additional Perl Modules
 ===============================


### PR DESCRIPTION
<!--

#### Instructions

1. All pull requests to an officially supported branch must be accompanied by a bug report on bugzilla.mozilla.org. Please stop and file one there if you haven't already, or look for an existing one that fits what you're doing (the bug entry form will automatically search for things that look similar to the Summary you enter).
   File a bug report: https://bugzilla.mozilla.org/enter_bug.cgi?product=Bugzilla
2. GitHub will automatically attach your pull request to the bug report in Bugzilla if you have "Bug #######" in the title of the pull request, where ####### is the bug number. For readability, we recommend putting it at the beginning of the title.
3. If it's not otherwise obvious from the title which branch the pull request applies to, please put the name of the branch in square brackets at the beginning of the title.

 Example title:
   [5.2] Bug 1234: Change Foo to do Bar
-->

#### Details
<!-- Explain what you did -->
This PR re-orders the Ubuntu Quick Start page to fetch the file to be copied before instructing the reader to copy it.

#### Additional info
<!-- Paste the bug number after the # and after the = in the following line. -->
* [bug#2040088](https://bugzilla.mozilla.org/show_bug.cgi?id=2040088)

#### Test Plan
<!-- How did you verify the fix/feature in steps -->
1. run makedocs.pl
2. check txt/installing/quick-start.txt
