### PR TITLE
[5.2] Bug 1764713 Easily switch between open/closed/both combined bugs in bug search list

### DIFF
--- a/skins/standard/buglist.css
+++ b/skins/standard/buglist.css
@@ -148,6 +148,38 @@ td.bz_total {
     color: inherit;
 }
 
+.bz_status_toggle {
+  margin: 0.5em 0;
+}
+
+.bz_status_toggle_label {
+  font-weight: bold;
+  margin-right: 0.4em;
+}
+
+.bz_status_toggle_btn {
+  display: inline-block;
+  padding: 0.2em 0.7em;
+  margin: 0 0.2em;
+  border: 1px solid #aaa;
+  border-radius: 3px;
+  text-decoration: none;
+  color: #333;
+  background: #f5f5f5;
+}
+
+.bz_status_toggle_btn:hover {
+  background: #e0e0e0;
+  border-color: #888;
+}
+
+.bz_status_toggle_btn.bz_status_toggle_active {
+  background: #336699;
+  color: #fff;
+  border-color: #336699;
+  font-weight: bold;
+}
+
 .buglist_menu {
     margin-top: 1em;
 }

--- a/template/en/default/list/list.html.tmpl
+++ b/template/en/default/list/list.html.tmpl
@@ -136,6 +136,36 @@
 <hr>
 
 [%############################################################################%]
+[%# Status Toggle                                                            #%]
+[%############################################################################%]
+
+<div class="bz_status_toggle">
+  <span class="bz_status_toggle_label">Show:</span>
+  <a id="status_toggle_open"   class="bz_status_toggle_btn" href="#">Open</a>
+  <a id="status_toggle_closed" class="bz_status_toggle_btn" href="#">Closed</a>
+  <a id="status_toggle_all"    class="bz_status_toggle_btn" href="#">All</a>
+</div>
+<script type="text/javascript">
+(function() {
+  if (typeof URLSearchParams === 'undefined') return;
+  var params = new URLSearchParams(window.location.search);
+  var statuses = params.getAll('bug_status');
+  var statusMap = { '__open__': 'open', '__closed__': 'closed', '__all__': 'all' };
+  var current = (statuses.length === 1) ? (statusMap[statuses[0]] || '') : '';
+
+  ['open', 'closed', 'all'].forEach(function(s) {
+    var p = new URLSearchParams(window.location.search);
+    p.delete('bug_status');
+    p.append('bug_status', '__' + s + '__');
+    var el = document.getElementById('status_toggle_' + s);
+    if (!el) return;
+    el.href = 'buglist.cgi?' + p.toString();
+    if (s === current) el.className += ' bz_status_toggle_active';
+  });
+})();
+</script>
+
+[%############################################################################%]
 [%# Preceding Status Line                                                    #%]
 [%############################################################################%]
 


### PR DESCRIPTION
#### Details

This PR adds a quick-toggle widget at the top of the bug list results page, allowing users to switch between open bugs, closed bugs, or all bugs without returning to the search form.

- The widget detects the current bug_status value from the URL (__open__, __closed__, __all__) and highlights the active button
- Links preserve all other existing search parameters (product, component, assignee, etc.), only replacing bug_status

#### Additional info

* [bug#1764713](https://bugzilla.mozilla.org/show_bug.cgi?id=1764713)

#### Test plan

1. Run a search returning open bugs (bug_status=__open__) -- Open button is highlighted
2. Click Closed -- redirects to the same search with bug_status=__closed__
3. Click All -- redirects with bug_status=__all__
4. Verify that other search parameters (product, assignee…) are preserved in the redirect
5. Verify display on a search with multiple bug_status values (no button highlighted)