### PR TITLE
[5.2] Bug 2042214: fix table format conversion in MariaDB

### DIFF
--- a/Bugzilla/DB/MariaDB.pm
+++ b/Bugzilla/DB/MariaDB.pm
@@ -354,7 +354,7 @@ sub bz_setup_database {
     die install_string('mysql_innodb_disabled');
   }
 
-  if ($self->utf8_charset eq 'utf8mb3') {
+  if ($self->utf8_charset eq 'utf8mb4') {
     my %global = map {@$_}
       @{$self->selectall_arrayref(q(SHOW GLOBAL VARIABLES LIKE 'innodb_%'))};
 


### PR DESCRIPTION
#### Details
The MariaDB driver was accidentally gating on the wrong character set when deciding whether the row format also needed to be updated. Simple one-line fix.

#### Additional info
* [bug#2042214](https://bugzilla.mozilla.org/show_bug.cgi?id=2042214)
