### PR TITLE
[5.3] Bug 1923778: Newer Perl hates PATH being empty

### DIFF
--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -87,7 +87,11 @@ sub init_page {
   }
 
   if (${^TAINT}) {
-    my $path = '';
+    # PATH *MUST* contain SOMETHING or newer Perls will throw an error. Everything
+    # Bugzilla shells out to uses absolute paths, except for the 'hostname' command
+    # used by Email::Sender, which is in /bin on all supported platforms.
+    # see https://bugzilla.mozilla.org/show_bug.cgi?id=1923778
+    my $path = '/bin';
     if (ON_WINDOWS) {
 
       # On Windows, these paths are tainted, preventing

--- a/Bugzilla.pm
+++ b/Bugzilla.pm
@@ -87,11 +87,10 @@ sub init_page {
   }
 
   if (${^TAINT}) {
-    # PATH *MUST* contain SOMETHING or newer Perls will throw an error. Everything
-    # Bugzilla shells out to uses absolute paths, except for the 'hostname' command
-    # used by Email::Sender, which is in /bin on all supported platforms.
+    # PATH *MUST* contain SOMETHING or newer Perls will throw an error. Keep this
+    # minimal and platform-specific so command lookups still work when needed.
     # see https://bugzilla.mozilla.org/show_bug.cgi?id=1923778
-    my $path = '/bin';
+    my $path = '/bin:/usr/bin';
     if (ON_WINDOWS) {
 
       # On Windows, these paths are tainted, preventing
@@ -101,12 +100,18 @@ sub init_page {
         trick_taint($ENV{$temp}) if $ENV{$temp};
       }
 
+      # Native Windows command lookup should include System32.
+      my $system_root = $ENV{SYSTEMROOT} || $ENV{WINDIR} || 'C:\\Windows';
+      trick_taint($system_root);
+      $path = "$system_root\\System32";
+
       # Some DLLs used by Strawberry Perl are also in c\bin,
       # see https://rt.cpan.org/Public/Bug/Display.html?id=99104
       if (!ON_ACTIVESTATE) {
-        my $c_path = $path = dirname($^X);
+        my $perl_path = dirname($^X);
+        my $c_path    = $perl_path;
         $c_path =~ s/\bperl\b(?=\\bin)/c/;
-        $path .= ";$c_path";
+        $path .= ";$perl_path;$c_path";
         trick_taint($path);
       }
     }


### PR DESCRIPTION
#### Details
Newer versions of Perl complain if PATH is either empty or tainted, so set a sensible default instead.

#### Additional info
* [bug#1923778](https://bugzilla.mozilla.org/show_bug.cgi?id=1923778)
