### PR TITLE
Bug 1922411: Remove dead server-push infrastructure

### DIFF
--- a/Bugzilla/CGI.pm
+++ b/Bugzilla/CGI.pm
@@ -260,50 +260,10 @@ sub check_etag {
   return 0;
 }
 
-# Have to add the cookies in.
-sub multipart_start {
-  my $self = shift;
-
-  my %args = @_;
-
-  # CGI.pm::multipart_start doesn't honour its own charset information, so
-  # we do it ourselves here
-  if (defined $self->charset() && defined $args{-type}) {
-
-    # Remove any existing charset specifier
-    $args{-type} =~ s/;.*$//;
-
-    # and add the specified one
-    $args{-type} .= '; charset=' . $self->charset();
-  }
-
-  my $headers = $self->SUPER::multipart_start(%args);
-
-  # Eliminate the one extra CRLF at the end.
-  $headers =~ s/$CGI::CRLF$//;
-
-  # Add the cookies. We have to do it this way instead of
-  # passing them to multpart_start, because CGI.pm's multipart_start
-  # doesn't understand a '-cookie' argument pointing to an arrayref.
-  foreach my $cookie (@{$self->{Bugzilla_cookie_list}}) {
-    $headers .= "Set-Cookie: ${cookie}${CGI::CRLF}";
-  }
-  $headers .= $CGI::CRLF;
-  $self->{_multipart_in_progress} = 1;
-  return $headers;
-}
-
 sub close_standby_message {
   my ($self, $contenttype, $disp, $disp_prefix, $extension) = @_;
   $self->set_dated_content_disp($disp, $disp_prefix, $extension);
-
-  if ($self->{_multipart_in_progress}) {
-    print $self->multipart_end();
-    print $self->multipart_start(-type => $contenttype);
-  }
-  elsif (!$self->{_header_done}) {
-    print $self->header($contenttype);
-  }
+  print $self->header($contenttype) if !$self->{_header_done};
 }
 
 our $ALLOW_UNSAFE_RESPONSE = 0;
@@ -800,14 +760,10 @@ instead of calling this directly.
 
 Redirects from the current URL to one prefixed by the urlbase parameter.
 
-=item C<multipart_start>
-
-Starts a new part of the multipart document using the specified MIME type.
-If not specified, text/html is assumed.
-
 =item C<close_standby_message>
 
-Ends a part of the multipart document, and starts another part.
+Sets the content disposition header and sends the response header if it has
+not already been sent.
 
 =item C<set_dated_content_disp>
 

--- a/Bugzilla/Error.pm
+++ b/Bugzilla/Error.pm
@@ -103,7 +103,6 @@ sub _throw_error {
     my $cgi = Bugzilla->cgi;
     $cgi->close_standby_message('text/html', 'inline', 'error', 'html');
     print $message;
-    print $cgi->multipart_final() if $cgi->{_multipart_in_progress};
   }
   elsif (Bugzilla->error_mode == ERROR_MODE_TEST) {
     die Dumper($vars);


### PR DESCRIPTION
With server-push removed from buglist.cgi, the multipart_start override in CGI.pm and the _multipart_in_progress guard in Error.pm are now unreachable. Simplify close_standby_message to its non-multipart path and drop the related dead code.

Just pushing this somewhere for an easy cherry-pick onto the existing PR