### PR TITLE
[5.0.4] Bug 1926298: blocklisted module not enforced due to typo

### DIFF
--- a/Bugzilla/Install/Requirements.pm
+++ b/Bugzilla/Install/Requirements.pm
@@ -127,7 +127,7 @@ sub REQUIRED_MODULES {
         package => 'Template-Toolkit',
         module  => 'Template',
         version => '2.24',
-        blacklist => ['^2.2[89]$', '^3.00[0-8]$']
+        blocklist => ['^2.2[89]$', '^3.00[0-8]$']
     },
     # 1.300011 has a debug mode for SMTP and automatically pass -i to sendmail.
     {

--- a/template/en/default/pages/release-notes.html.tmpl
+++ b/template/en/default/pages/release-notes.html.tmpl
@@ -84,7 +84,7 @@ provide security updates without the invasive changes. <b>This release track of
   type correctly on emails.
   (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1657496">[% terms.Bug %] 1657496</a>)</li>
 
-  <li>Template Toolkit versions 2.28 through 3.007 are blacklisted due to a
+  <li>Template Toolkit versions 2.28 through 3.007 are blocklisted due to a
   compatibility issue.  Versions 2.22 through 2.27 and 3.008 and later are
   still supported.
   (<a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1560873">[% terms.Bug %] 1560873</a>)</li>


### PR DESCRIPTION
#### Details
Fixes blacklist -> blocklist renames that were missed in the 5.0.4.1 release

#### Additional info
* [bug#1926298](https://bugzilla.mozilla.org/show_bug.cgi?id=1926298)
