### PR TITLE
[5.2] Bug 2057316 Fix table content wrapping in docs

### DIFF
--- a/docs/en/rst/_static/bugzilla.css
+++ b/docs/en/rst/_static/bugzilla.css
@@ -3,3 +3,14 @@
   min-width: 150px;
   width: 350px;
 }
+
+.wy-table-responsive table td,
+.wy-table-responsive table th {
+  white-space: wrap;
+}
+
+.rst-content table.docutils td,
+.rst-content table.field-list td,
+.wy-table td {
+	vertical-align: top;
+}


### PR DESCRIPTION
<!--

#### Instructions

1. All pull requests to an officially supported branch must be accompanied by a bug report on bugzilla.mozilla.org. Please stop and file one there if you haven't already, or look for an existing one that fits what you're doing (the bug entry form will automatically search for things that look similar to the Summary you enter).
   File a bug report: https://bugzilla.mozilla.org/enter_bug.cgi?product=Bugzilla
2. GitHub will automatically attach your pull request to the bug report in Bugzilla if you have "Bug #######" in the title of the pull request, where ####### is the bug number. For readability, we recommend putting it at the beginning of the title.
3. If it's not otherwise obvious from the title which branch the pull request applies to, please put the name of the branch in square brackets at the beginning of the title.

 Example title:
   [5.2] Bug 1234: Change Foo to do Bar
-->

#### Details
<!-- Explain what you did -->
Prevent table cell content from overflowing

<img width="500" alt="image" src="https://github.com/user-attachments/assets/9d9f671c-a3c1-4f58-82ef-3a38fadf890d" />

#### Additional info
<!-- Paste the bug number after the # and after the = in the following line. -->
* [bug#2057316](https://bugzilla.mozilla.org/show_bug.cgi?id=2057316)

#### Test Plan
<!-- How did you verify the fix/feature in steps -->
1. Generate the documentation
2. Open a documentation page with a table (e.g. http://127.0.0.1:8000/api/core/v1/bug.html#get-bug)
3. Validate that the text is properly wrapped instead of creating an scrollable overflow.
