### PR TITLE
[5.0.4] Bug 2007801: The component field in request.cgi was empty unless action=queue is part of the URL

### DIFF
--- a/request.cgi
+++ b/request.cgi
@@ -53,13 +53,15 @@ if ($action eq 'queue') {
 else {
     my $flagtypes = get_flag_types();
     my @types = ('all', @$flagtypes);
+    my $products = $user->get_selectable_products;
 
     my $vars = {};
     $vars->{'types'} = \@types;
     $vars->{'requests'} = {};
+    $vars->{'products'} = $products;
 
     my %components;
-    foreach my $prod (@{$user->get_selectable_products}) {
+    foreach my $prod (@$products) {
         foreach my $comp (@{$prod->components}) {
             $components{$comp->name} = 1;
         }


### PR DESCRIPTION
#### Additional info
* [bug#2007801](https://bugzilla.mozilla.org/show_bug.cgi?id=2007801)

Patch authored by LpSolit