### PR TITLE
[5.0.4] Bug 1308109: Fix crash when displaying "Blocks" or "Dedends on" as column on Oracle

### DIFF
--- a/Bugzilla/DB/Oracle.pm
+++ b/Bugzilla/DB/Oracle.pm
@@ -114,7 +114,7 @@ sub sql_group_concat {
     my ($self, $text, $separator) = @_;
     $separator = $self->quote(', ') if !defined $separator;
     my ($distinct, $rest) = $text =~/^(\s*DISTINCT\s|)(.+)$/i;
-    return "group_concat($distinct T_CLOB_DELIM(NVL($rest, ' '), $separator))";
+    return "group_concat($distinct T_CLOB_DELIM(NVL(TO_CHAR($rest), ' '), $separator))";
 }
 
 sub sql_regexp {


### PR DESCRIPTION
#### Additional info

* [bug#1308109](https://bugzilla.mozilla.org/show_bug.cgi?id=1308109)

Patch author: LpSolit