### PR TITLE
[5.0.4] Bug 889650: Fix crash when searching "match all of the same field" on…

### DIFF
--- a/Bugzilla/Search.pm
+++ b/Bugzilla/Search.pm
@@ -2919,7 +2919,7 @@ sub _flagtypes_nonchanged {
     # don't call build_subselect as this must run as a true sub-select
     $args->{term} = "EXISTS (
         SELECT 1
-          FROM $bugs_table bugs_$chart_id
+          FROM bugs bugs_$chart_id
           LEFT JOIN attachments AS attachments_$chart_id
                     ON bugs_$chart_id.bug_id = attachments_$chart_id.bug_id
           LEFT JOIN flags AS flags_$chart_id

--- a/xt/lib/Bugzilla/Test/Search/Constants.pm
+++ b/xt/lib/Bugzilla/Test/Search/Constants.pm
@@ -1198,6 +1198,16 @@ use constant CUSTOM_SEARCH_TESTS => (
       ]
     },
 
+    {
+      name       => 'flagtypes.name = <1> AND flagtypes.name = <1>',
+      contains   => [1],
+      top_params => {j_top => 'AND_G'},
+      params     => [
+          {f => 'flagtypes.name', o => 'equals', v => '<1>'},
+          {f => 'flagtypes.name', o => 'equals', v => '<1>'},
+      ]
+    },
+
 );
 
 1;


### PR DESCRIPTION
#### Details
Fixed the grouped flag search aliasing in Search.pm so the subquery now reads from the real bugs table instead of the grouped alias, which avoids the missing bugs_g2 table error.

#### Additional info
* [bug#889650](https://bugzilla.mozilla.org/show_bug.cgi?id=889650)

#### Test Plan
1. Replicated the error on an up-to-date Bugzilla 5.0.4 branch installation (version 5.0.4.1+ on landfill)
2. Applied this patch
3. Re-ran the identical search and observed that it
  * Ran without crashing
  * produced the correct results (only matching bugs that had both items set)
