### PR TITLE
[5.2] Bug 2051802: Allow UTF8 conversion override non-interactively

### DIFF
--- a/Bugzilla/DB/MariaDB.pm
+++ b/Bugzilla/DB/MariaDB.pm
@@ -728,8 +728,17 @@ sub bz_setup_database {
     print "\n", install_string('mysql_utf8_conversion');
 
     if (!Bugzilla->installation_answers->{NO_PAUSE}) {
+      my $allow_unsafe_utf8_conversion
+        = Bugzilla->installation_answers->{ALLOW_UNSAFE_UTF8_CONVERSION};
       if (Bugzilla->installation_mode == INSTALLATION_MODE_NON_INTERACTIVE) {
-        die install_string('continue_without_answers'), "\n";
+        if ($allow_unsafe_utf8_conversion) {
+          print "\n"
+            . install_string('continuing_with_unsafe_utf8_conversion')
+            . "\n";
+        }
+        else {
+          die install_string('continue_without_answers'), "\n";
+        }
       }
       else {
         print "\n         " . install_string('enter_or_ctrl_c');

--- a/Bugzilla/DB/MariaDB.pm
+++ b/Bugzilla/DB/MariaDB.pm
@@ -786,7 +786,6 @@ sub bz_setup_database {
           push(@binary_sql, "MODIFY COLUMN $name $binary");
           push(@utf8_sql,   "MODIFY COLUMN $name $utf8");
         }
-      }
       }    # foreach column
 
       if (@binary_sql) {

--- a/Bugzilla/DB/MariaDB.pm
+++ b/Bugzilla/DB/MariaDB.pm
@@ -727,23 +727,19 @@ sub bz_setup_database {
   if (Bugzilla->params->{'utf8'} && $non_utf8_tables) {
     print "\n", install_string('mysql_utf8_conversion');
 
-    if (!Bugzilla->installation_answers->{NO_PAUSE}) {
-      my $allow_unsafe_utf8_conversion
-        = Bugzilla->installation_answers->{ALLOW_UNSAFE_UTF8_CONVERSION};
-      if (Bugzilla->installation_mode == INSTALLATION_MODE_NON_INTERACTIVE) {
-        if ($allow_unsafe_utf8_conversion) {
-          print "\n"
-            . install_string('continuing_with_unsafe_utf8_conversion')
-            . "\n";
-        }
-        else {
-          die install_string('continue_without_answers'), "\n";
-        }
-      }
-      else {
-        print "\n         " . install_string('enter_or_ctrl_c');
-        getc;
-      }
+    my $allow_unsafe_utf8_conversion
+      = Bugzilla->installation_answers->{ALLOW_UNSAFE_UTF8_CONVERSION};
+    if ($allow_unsafe_utf8_conversion) {
+      print "\n"
+        . install_string('continuing_with_unsafe_utf8_conversion')
+        . "\n";
+    }
+    elsif (Bugzilla->installation_mode == INSTALLATION_MODE_NON_INTERACTIVE) {
+      die install_string('continue_without_answers'), "\n";
+    }
+    else {
+      print "\n         " . install_string('enter_or_ctrl_c');
+      getc;
     }
 
     print
@@ -790,6 +786,7 @@ sub bz_setup_database {
           push(@binary_sql, "MODIFY COLUMN $name $binary");
           push(@utf8_sql,   "MODIFY COLUMN $name $utf8");
         }
+      }
       }    # foreach column
 
       if (@binary_sql) {

--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -728,8 +728,17 @@ sub bz_setup_database {
     print "\n", install_string('mysql_utf8_conversion');
 
     if (!Bugzilla->installation_answers->{NO_PAUSE}) {
+      my $allow_unsafe_utf8_conversion
+        = Bugzilla->installation_answers->{ALLOW_UNSAFE_UTF8_CONVERSION};
       if (Bugzilla->installation_mode == INSTALLATION_MODE_NON_INTERACTIVE) {
-        die install_string('continue_without_answers'), "\n";
+        if ($allow_unsafe_utf8_conversion) {
+          print "\n"
+            . install_string('continuing_with_unsafe_utf8_conversion')
+            . "\n";
+        }
+        else {
+          die install_string('continue_without_answers'), "\n";
+        }
       }
       else {
         print "\n         " . install_string('enter_or_ctrl_c');

--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -786,7 +786,6 @@ sub bz_setup_database {
           push(@binary_sql, "MODIFY COLUMN $name $binary");
           push(@utf8_sql,   "MODIFY COLUMN $name $utf8");
         }
-      }
       }    # foreach column
 
       if (@binary_sql) {

--- a/Bugzilla/DB/Mysql.pm
+++ b/Bugzilla/DB/Mysql.pm
@@ -727,23 +727,19 @@ sub bz_setup_database {
   if (Bugzilla->params->{'utf8'} && $non_utf8_tables) {
     print "\n", install_string('mysql_utf8_conversion');
 
-    if (!Bugzilla->installation_answers->{NO_PAUSE}) {
-      my $allow_unsafe_utf8_conversion
-        = Bugzilla->installation_answers->{ALLOW_UNSAFE_UTF8_CONVERSION};
-      if (Bugzilla->installation_mode == INSTALLATION_MODE_NON_INTERACTIVE) {
-        if ($allow_unsafe_utf8_conversion) {
-          print "\n"
-            . install_string('continuing_with_unsafe_utf8_conversion')
-            . "\n";
-        }
-        else {
-          die install_string('continue_without_answers'), "\n";
-        }
-      }
-      else {
-        print "\n         " . install_string('enter_or_ctrl_c');
-        getc;
-      }
+    my $allow_unsafe_utf8_conversion
+      = Bugzilla->installation_answers->{ALLOW_UNSAFE_UTF8_CONVERSION};
+    if ($allow_unsafe_utf8_conversion) {
+      print "\n"
+        . install_string('continuing_with_unsafe_utf8_conversion')
+        . "\n";
+    }
+    elsif (Bugzilla->installation_mode == INSTALLATION_MODE_NON_INTERACTIVE) {
+      die install_string('continue_without_answers'), "\n";
+    }
+    else {
+      print "\n         " . install_string('enter_or_ctrl_c');
+      getc;
     }
 
     print
@@ -790,6 +786,7 @@ sub bz_setup_database {
           push(@binary_sql, "MODIFY COLUMN $name $binary");
           push(@utf8_sql,   "MODIFY COLUMN $name $utf8");
         }
+      }
       }    # foreach column
 
       if (@binary_sql) {

--- a/README
+++ b/README
@@ -22,6 +22,13 @@ and type `docker compose up`. The URL to access and the username and password
 for the default admin account will be shown on the console once it finishes
 setting it up.
 
+If checksetup.pl stops in Docker because UTF-8 conversion requires an
+interactive confirmation, you can explicitly allow that conversion with:
+
+	BZ_ALLOW_UNSAFE_UTF8_CONVERSION=1 docker compose up
+
+Only do this if you understand the warning and have a backup of your data.
+
 Reporting Bugs
 ==============
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - BZ_DB_USER=bugs
       - BZ_DB_NAME=bugs
       - BZ_DB_PASS=bugzilla
+      - BZ_ALLOW_UNSAFE_UTF8_CONVERSION=${BZ_ALLOW_UNSAFE_UTF8_CONVERSION:-0}
       - MARIADB_ROOT_HOST=%
       - MARIADB_ROOT_PASSWORD=bugzilla
 

--- a/docker/checksetup_answers.txt
+++ b/docker/checksetup_answers.txt
@@ -37,3 +37,4 @@ $answer{'db_mysql_ssl_ca_file'}     = '';
 $answer{'db_mysql_ssl_ca_path'}     = '';
 $answer{'db_mysql_ssl_client_cert'} = '';
 $answer{'db_mysql_ssl_client_key'}  = '';
+$answer{'ALLOW_UNSAFE_UTF8_CONVERSION'} = %%BZ_ALLOW_UNSAFE_UTF8_CONVERSION%%;

--- a/docker/checksetup_answers.txt
+++ b/docker/checksetup_answers.txt
@@ -2,6 +2,7 @@ $answer{'ADMIN_EMAIL'}          = %%BZ_ADMIN_EMAIL%%;
 $answer{'ADMIN_OK'}             = 'Y';
 $answer{'ADMIN_PASSWORD'}       = %%BZ_ADMIN_PASSWORD%%;
 $answer{'ADMIN_REALNAME'}       = %%BZ_ADMIN_REALNAME%%;
+$answer{'NO_PAUSE'}             = '1';
 $answer{'webservergroup'}       = 'www-data';
 $answer{'use_suexec'}           = '0';
 $answer{'db_driver'}            = 'mariadb';

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -43,8 +43,30 @@ s/%%BZ_DB_NAME%%/'$BZ_DB_NAME'/;
 s/%%BZ_DB_USER%%/'$BZ_DB_USER'/;
 s/%%BZ_DB_PASS%%/'${BZ_DB_PASS//@/\\@//$/\\$}'/;
 s@%%BZ_URLBASE%%@'${BZ_URLBASE//@/\\@}'@;
+s/%%BZ_ALLOW_UNSAFE_UTF8_CONVERSION%%/${BZ_ALLOW_UNSAFE_UTF8_CONVERSION:-0}/;
 " /root/docker/checksetup_answers.txt
-perl checksetup.pl /root/docker/checksetup_answers.txt
+
+CHECKSETUP_LOG=$(mktemp)
+perl checksetup.pl /root/docker/checksetup_answers.txt 2>&1 | tee "$CHECKSETUP_LOG"
+CHECKSETUP_EXIT=${PIPESTATUS[0]}
+
+if [ $CHECKSETUP_EXIT -ne 0 ]; then
+  if grep -q "Re-run checksetup.pl in interactive mode" "$CHECKSETUP_LOG"; then
+    cat - <<EOF
+
+checksetup.pl stopped because a potentially destructive conversion requires
+explicit approval in non-interactive mode.
+
+To proceed with the UTF-8 conversion in Docker, re-run with:
+  BZ_ALLOW_UNSAFE_UTF8_CONVERSION=1 docker compose up
+
+Only use this if you understand the warning and have a database backup.
+EOF
+  fi
+  exit $CHECKSETUP_EXIT
+fi
+
+rm -f "$CHECKSETUP_LOG"
 echo "Checksetup completed."
 
 LOGIN_USER="Admin user: $BZ_ADMIN_EMAIL"

--- a/template/en/default/setup/strings.txt.pl
+++ b/template/en/default/setup/strings.txt.pl
@@ -54,6 +54,13 @@ EOT
   continue_without_answers => <<'END',
 Re-run checksetup.pl in interactive mode (without an 'answers' file)
 to continue.
+
+To continue non-interactively, set ALLOW_UNSAFE_UTF8_CONVERSION to 1
+in your answers file.
+END
+  continuing_with_unsafe_utf8_conversion => <<'END',
+WARNING: ALLOW_UNSAFE_UTF8_CONVERSION is enabled. Continuing the UTF-8
+         conversion without an interactive confirmation prompt.
 END
   cpan_bugzilla_home => "WARNING: Using the Bugzilla directory as the CPAN home.",
   db_blocklisted     => <<END,


### PR DESCRIPTION
#### Details
When Docker hits the non-interactive UTF-8 conversion bailout, console output now prints a clear hint showing how to proceed explicitly:

BZ_ALLOW_UNSAFE_UTF8_CONVERSION=1 docker compose up

What changed

1. Docker startup now fails fast if checksetup fails, and prints the override hint when that specific UTF-8 prompt bailout occurs: bugzilla/docker/startup.sh
2. New Docker env var is wired into the generated answers file
3. Checksetup DB code now honors ALLOW_UNSAFE_UTF8_CONVERSION=1 in non-interactive mode (instead of always dying at that point)
4. User-facing setup text updated to document the answers-file override
5. Docker quick-start README note added: bugzilla/README

Net effect

1. If you do nothing, behavior stays safe (default is 0, so it still blocks).
2. If you explicitly opt in, conversion runs non-interactively.
3. If conversion blocks and exits, Docker no longer pretends setup succeeded.

#### Additional info
* [bug#2051802](https://bugzilla.mozilla.org/show_bug.cgi?id=2051802)

#### Test Plan
1. Ran `docker compose up`
2. After it came up, used the Files tab in Docker Desktop to drop a database dump from 5.06 into the root directory on the MySQL container
3. Used the Exec tab in Docker Desktop to open a shell and restore that dump into the database.
4. Ran `docker compose down`
5. Ran `docker compose up` and verified that the conversion bailed with the new messaging.
6. Ran `ALLOW_UNSAFE_UTF8_CONVERSION=1 docker compose up` and verified that the conversion proceeded.
