### PR TITLE
[5.0.4] Bug 681635: De-duplicate values in Advanced Search

### DIFF
--- a/js/productform.js
+++ b/js/productform.js
@@ -215,53 +215,24 @@ function fake_diff_array(a, b) {
  * @return             Merged and sorted array.
  */
 function merge_arrays(a, b, b_is_select) {
-    var pos_a = 0;
-    var pos_b = 0;
+    var items = a.slice();
     var ret = new Array();
-    var bitem, aitem;
+    var i;
 
-    // Iterate through both arrays and add the larger item to the return
-    // list. Remove dupes, too. Use toLowerCase to provide
-    // case-insensitivity.
-    while ((pos_a < a.length) && (pos_b < b.length)) {
-        aitem = a[pos_a];
-        if (b_is_select)
-            bitem = b[pos_b].value;
-        else
-            bitem = b[pos_b];
+    for (i = 0; i < b.length; i++)
+        items[items.length] = b_is_select ? b[i].value : b[i];
 
-        // Smaller item in list a.
-        if (aitem.toLowerCase() < bitem.toLowerCase()) {
-            ret[ret.length] = aitem;
-            pos_a++;
-        }
-        else {
-            // Smaller item in list b.
-            if (aitem.toLowerCase() > bitem.toLowerCase()) {
-                ret[ret.length] = bitem;
-                pos_b++;
-            }
-            else {
-                // List contents are equal, include both counters.
-                ret[ret.length] = aitem;
-                pos_a++;
-                pos_b++;
-            }
-        }
-    }
+    items.sort(function(left, right) {
+        left = left.toLowerCase();
+        right = right.toLowerCase();
+        return left < right ? -1 : left > right ? 1 : 0;
+    });
 
-    // Catch leftovers here. These sections are ugly code-copying.
-    if (pos_a < a.length)
-        for (; pos_a < a.length ; pos_a++)
-            ret[ret.length] = a[pos_a];
-
-    if (pos_b < b.length) {
-        for (; pos_b < b.length; pos_b++) {
-            if (b_is_select)
-                bitem = b[pos_b].value;
-            else
-                bitem = b[pos_b];
-            ret[ret.length] = bitem;
+    for (i = 0; i < items.length; i++) {
+        if (!ret.length
+            || items[i].toLowerCase() != ret[ret.length - 1].toLowerCase())
+        {
+            ret[ret.length] = items[i];
         }
     }
 

--- a/t/015productform.t
+++ b/t/015productform.t
@@ -1,0 +1,94 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+
+##################
+#Bugzilla Test 15#
+####Productform###
+
+use 5.10.1;
+use strict;
+use warnings;
+
+use File::Spec;
+use Test::More;
+
+my $node;
+foreach my $dir (File::Spec->path()) {
+  foreach my $name (qw(node node.exe)) {
+    my $path = File::Spec->catfile($dir, $name);
+    if (-x $path && !-d $path) {
+      $node = $path;
+      last;
+    }
+  }
+  last if $node;
+}
+
+if (!$node) {
+  plan tests => 1;
+  fail('Node.js is required to test js/productform.js');
+  exit;
+}
+
+my $script = <<'JS';
+var fs = require('fs');
+var vm = require('vm');
+
+vm.runInThisContext(
+  fs.readFileSync('js/productform.js', 'utf8'),
+  { filename: 'js/productform.js' }
+);
+
+console.log(
+  merge_arrays(
+    ['Trunk', '2.0'],
+    ['unspecified', 'Trunk'],
+    false
+  ).join('\t')
+);
+console.log(
+  merge_arrays(
+    ['Beta', 'alpha'],
+    [{ value: 'ALPHA' }, { value: 'Release' }],
+    true
+  ).join('\t')
+);
+JS
+
+my $pid = open(my $fh, '-|', $node, '-e', $script);
+if (!defined $pid) {
+  plan tests => 1;
+  fail("could not run $node: $!");
+  exit;
+}
+
+my @results = <$fh>;
+close($fh);
+my $status = $?;
+
+if ($status || @results != 2) {
+  plan tests => 1;
+  fail('js/productform.js did not produce the expected test output');
+  diag("Node.js exit status: $status");
+  diag("Node.js output:\n" . join('', @results));
+  exit;
+}
+
+chomp(@results);
+plan tests => 2;
+
+is_deeply(
+  [split(/\t/, $results[0])],
+  ['2.0', 'Trunk', 'unspecified'],
+  'unsorted product values are sorted and de-duplicated'
+);
+is_deeply(
+  [split(/\t/, $results[1])],
+  ['alpha', 'Beta', 'Release'],
+  'select options are merged, sorted, and de-duplicated'
+);


### PR DESCRIPTION
#### Details
Advanced Search can show duplicate version or target milestone values when selected products use configured ordering rather than case-insensitive alphabetical ordering. `merge_arrays` used a two-pointer merge that assumed both inputs were already sorted, so overlapping values at different positions were not recognized as duplicates.

This is the `5.0.4` port of #244. It combines both inputs, sorts them case-insensitively, and then removes adjacent case-insensitive duplicates while preserving the incremental path that merges existing `<select>` options. A Perl TAP regression test executes the production JavaScript with Node and fails clearly if Node is unavailable.

#### Additional info
* [bug 681635](https://bugzilla.mozilla.org/show_bug.cgi?id=681635)

#### Test Plan
1. Run `node --check js/productform.js`.
2. Run `perl runtests.pl 15`.
3. Confirm both the unsorted overlapping-values case and the incremental select-options case pass.
