### PR TITLE
[master] Bug 681635: De-duplicate values in Advanced Search

### DIFF
--- a/js/productform.js
+++ b/js/productform.js
@@ -215,53 +215,24 @@ function fake_diff_array(a, b) {
  * @return             Merged and sorted array.
  */
 function merge_arrays(a, b, b_is_select) {
-    var pos_a = 0;
-    var pos_b = 0;
+    var items = a.slice();
     var ret = new Array();
-    var bitem, aitem;
+    var i;
 
-    // Iterate through both arrays and add the larger item to the return
-    // list. Remove dupes, too. Use toLowerCase to provide
-    // case-insensitivity.
-    while ((pos_a < a.length) && (pos_b < b.length)) {
-        aitem = a[pos_a];
-        if (b_is_select)
-            bitem = b[pos_b].value;
-        else
-            bitem = b[pos_b];
+    for (i = 0; i < b.length; i++)
+        items[items.length] = b_is_select ? b[i].value : b[i];
 
-        // Smaller item in list a.
-        if (aitem.toLowerCase() < bitem.toLowerCase()) {
-            ret[ret.length] = aitem;
-            pos_a++;
-        }
-        else {
-            // Smaller item in list b.
-            if (aitem.toLowerCase() > bitem.toLowerCase()) {
-                ret[ret.length] = bitem;
-                pos_b++;
-            }
-            else {
-                // List contents are equal, include both counters.
-                ret[ret.length] = aitem;
-                pos_a++;
-                pos_b++;
-            }
-        }
-    }
+    items.sort(function(left, right) {
+        left = left.toLowerCase();
+        right = right.toLowerCase();
+        return left < right ? -1 : left > right ? 1 : 0;
+    });
 
-    // Catch leftovers here. These sections are ugly code-copying.
-    if (pos_a < a.length)
-        for (; pos_a < a.length ; pos_a++)
-            ret[ret.length] = a[pos_a];
-
-    if (pos_b < b.length) {
-        for (; pos_b < b.length; pos_b++) {
-            if (b_is_select)
-                bitem = b[pos_b].value;
-            else
-                bitem = b[pos_b];
-            ret[ret.length] = bitem;
+    for (i = 0; i < items.length; i++) {
+        if (!ret.length
+            || items[i].toLowerCase() != ret[ret.length - 1].toLowerCase())
+        {
+            ret[ret.length] = items[i];
         }
     }
 

--- a/xt/selenium/productform.t
+++ b/xt/selenium/productform.t
@@ -1,0 +1,60 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# This Source Code Form is "Incompatible With Secondary Licenses", as
+# defined by the Mozilla Public License, v. 2.0.
+
+use 5.14.0;
+use strict;
+use warnings;
+
+use FindBin qw($RealBin);
+use lib "$RealBin/../lib", "$RealBin/../../local/lib/perl5";
+
+use QA::Util;
+use Test::More "no_plan";
+
+my ($sel, $config) = get_selenium();
+
+log_in($sel, $config, 'admin');
+$sel->open_ok("/$config->{bugzilla_installation}/editflagtypes.cgi");
+$sel->title_is("Administer Flag Types");
+
+my $script = <<'JS';
+var arrayResult = document.createElement('div');
+arrayResult.id = 'merge_arrays_result';
+arrayResult.appendChild(document.createTextNode(
+  merge_arrays(
+    ['Trunk', '2.0'],
+    ['unspecified', 'Trunk'],
+    false
+  ).join('|')
+));
+document.body.appendChild(arrayResult);
+
+var selectResult = document.createElement('div');
+selectResult.id = 'merge_select_result';
+selectResult.appendChild(document.createTextNode(
+  merge_arrays(
+    ['Beta', 'alpha'],
+    [{ value: 'ALPHA' }, { value: 'Release' }],
+    true
+  ).join('|')
+));
+document.body.appendChild(selectResult);
+JS
+
+$sel->run_script($script);
+$sel->text_is(
+  'merge_arrays_result',
+  '2.0|Trunk|unspecified',
+  'unsorted product values are sorted and de-duplicated'
+);
+$sel->text_is(
+  'merge_select_result',
+  'alpha|Beta|Release',
+  'select options are merged, sorted, and de-duplicated'
+);
+
+logout($sel);


### PR DESCRIPTION
#### Details
Advanced Search can show duplicate version or target milestone values when selected products use configured ordering rather than case-insensitive alphabetical ordering. `merge_arrays` used a two-pointer merge that assumed both inputs were already sorted, so overlapping values at different positions were not recognized as duplicates.

This is the `master` port of #244. It combines both inputs, sorts them case-insensitively, and then removes adjacent case-insensitive duplicates while preserving the incremental path that merges existing `<select>` options. Browser-based regression coverage exercises the production function for both unsorted overlapping values and existing select options.

#### Additional info
* [bug 681635](https://bugzilla.mozilla.org/show_bug.cgi?id=681635)

#### Test Plan
1. In the configured Bugzilla Selenium environment, run `prove -f -v xt/selenium/productform.t` (13 tests).
2. Run `prove -f -v t/001compile.t t/002goodperl.t t/005whitespace.t` (3,897 tests).
3. Confirm both suites pass.
