### PR TITLE
[5.2] Bug 2069203: Fix crash loading Oracle database driver

### DIFF
--- a/Bugzilla/DB/Oracle.pm
+++ b/Bugzilla/DB/Oracle.pm
@@ -748,7 +748,7 @@ use 5.14.0;
 use strict;
 use warnings;
 
-use base -norequire, qw(DBI::st);
+use parent -norequire, qw(DBI::st);
 
 sub fetchrow_arrayref {
   my $self = shift;


### PR DESCRIPTION
#### Details
Oracle driver wouldn't load on the 5.2 branch due to `use base` not accepting the `-norequire` modifier. Need to use `use parent` instead in order to use that, and we still have to use it because it's a generated module and not one that can be loaded from disk, so we have to make sure it doesn't try to load it from disk.

#### Additional info
* [bug#2069203](https://bugzilla.mozilla.org/show_bug.cgi?id=2069203)
